### PR TITLE
chore: add Dependabot config with grouped security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      security:
+        applies-to: security-updates
+        patterns: ["*"]
+      minor-and-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: "npm"
+    directory: "/worker"
+    schedule:
+      interval: "weekly"
+    groups:
+      security:
+        applies-to: security-updates
+        patterns: ["*"]
+      minor-and-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with grouped updates so security fixes arrive as a **single batched PR** per ecosystem/directory instead of ~12 individual PRs for the current alerts.
- Covers root npm (`yarn.lock`), `worker/` npm (Cloudflare worker `package-lock.json`), and GitHub Actions.
- Groups: `security` (all security advisories → one PR), `minor-and-patch` (routine version bumps → one PR). Majors still open individually so they get reviewed.

## Follow-up after merge
Enable **Settings → Code security → Dependabot security updates** if not already on. Dependabot will then open a grouped PR for the existing 12 alerts on its next tick (can be triggered manually from the Insights → Dependency graph → Dependabot tab).

## Test plan
- [ ] Merge, verify Dependabot opens a single grouped security PR for the open alerts
- [ ] Confirm worker/ alerts (undici) are covered by the `/worker` entry