### PR TITLE
Add Ars Technica AI policy digest and /ai principles block

### DIFF
--- a/src/site/ai.njk
+++ b/src/site/ai.njk
@@ -44,6 +44,12 @@ I use AI in my writing workflow, far more than I'd have predicted a year ago. He
 
 My approach keeps evolving. Posts remain primarily me-authored; AI helps with capturing ideas, roughing out structure, and pressure-testing arguments.
 
+## Where the line is
+
+AI is useful for the tedious parts of a task: drafting structure from a transcript, catching typos, pressure-testing an argument, generating hero images. It is not useful as the author. Posts on this site are me-authored; arguments, framing, and judgment calls stay mine.
+
+When AI plays a meaningful role in a specific artifact (the [hero images generated with FLUX.2-dev](/posts/20260303-generating-blog-art/) being the most common example), I note it on the relevant post. See my [digest of Ars Technica's newsroom AI policy](/posts/20260423-digesting-ars-technica-ai-newsroom-policy/) for why I think this kind of line is worth drawing explicitly.
+
 ## A common writing workflow now
 
 > TL;DR: I capture ideas quickly, structure with AI, write the content myself, then use AI to pressure-test and format.

--- a/src/site/posts/20260423-digesting-ars-technica-ai-newsroom-policy.njk
+++ b/src/site/posts/20260423-digesting-ars-technica-ai-newsroom-policy.njk
@@ -1,0 +1,34 @@
+---
+title: "Why 'reviewed' should be a protected verb"
+layout: layouts/digesting.njk
+teaser: "A newsroom AI policy that closes the quote-attribution loophole and treats 'reviewed' as a protected verb."
+date: 2026-04-23
+digest_link: https://arstechnica.com/staff/2026/04/our-newsroom-ai-policy/
+tags: digesting
+topics:
+  - AI
+  - editorial standards
+  - content governance
+  - policy
+kens_status: draft
+---
+
+{% markdown %}
+
+Yesterday Ars Technica [published its newsroom AI policy](https://arstechnica.com/staff/2026/04/our-newsroom-ai-policy/).
+
+The short version from editor Ken Fisher: "Ars Technica is written by humans. AI doesn't write our stories, generate our images, or put words in anyone's mouth."
+
+It also names a balance I keep trying to strike in my own work, whether with the dev team on code review and documentation or in broader communications: finding where AI can responsibly ease tedious aspects of tasks without corroding the creative and less-hallucinatory parts of the human role. Ars draws that line in a concrete place:
+
+> AI tools must not be used to generate, extract, or summarize material that is then attributed to a named source, whether as a direct quote, a paraphrase, or a characterization of someone’s views.
+
+Reflecting on it stirs memories of art professors who have students help with tedious parts of a larger work: building canvases, cleaning paints, sometimes laying in background areas. The students get practice and exposure, and the professor keeps attention on the parts only they can do. It works until the professor asks for too much and the student becomes the creative author. AI can drift the same way when no one draws the line explicitly.
+
+It's the second public, carefully worded AI policy I've flagged recently; the first was [Fedora's for open-source contributions](/posts/20251104-digesting-fedora-ai-contribution-policy/), and the two rhyme more than I expected.
+
+Both policies echo a similar refrain: authors using AI tools must disclose that use. It doesn't automatically make it into the published piece; it just makes it impossible to use AI invisibly.
+
+These kinds of public policies still seem to be an exception, but it's nice to see them becoming more common.
+
+{% endmarkdown %}


### PR DESCRIPTION
## Summary
- New digesting post: *"Why 'reviewed' should be a protected verb"* — reacts to Ars Technica's newsroom AI policy (2026-04-22), framed around the tedious-vs-authorial line and a studio-apprentice analogy. Cross-links to the earlier Fedora AI policy digest.
- Adds a "Where the line is" principles block to `/ai` with the same framing; discloses that hero images are the most common AI-produced artifact on the site and links to the new digest.

## Test plan
- [ ] `yarn build` runs clean
- [ ] Digest post renders at `/posts/20260423-digesting-ars-technica-ai-newsroom-policy/`
- [ ] `/ai` renders with the new "Where the line is" section and link to the digest
- [ ] Internal link from digest → `/posts/20251104-digesting-fedora-ai-contribution-policy/` resolves
- [ ] Title still reads well against the body (or updated before publication)
- [ ] `kens_status: draft` — not yet ready for publication