### PR TITLE
ci: disable auto-deploy for feedback worker

### DIFF
--- a/.github/workflows/deploy-feedback-worker.yml
+++ b/.github/workflows/deploy-feedback-worker.yml
@@ -1,9 +1,21 @@
 name: Deploy Feedback Worker
+# NOTE: This workflow has never successfully run (all 3 attempts failed since Feb 2026).
+# The worker at feedback.allaboutken.com has always been deployed manually from local:
+#
+#   cd worker && npx wrangler deploy
+#
+# To re-enable auto-deploy, two things are needed:
+#   1. Add CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID to repo secrets
+#      (Settings → Secrets and variables → Actions)
+#   2. Verify the token is still active in the Cloudflare dashboard
+#      (My Profile → API Tokens)
+#
+# Auto-deploy on push is disabled below until those are in place.
 on:
-  push:
-    branches: [main]
-    paths: ['worker/**']
   workflow_dispatch:
+  # push:
+  #   branches: [main]
+  #   paths: ['worker/**']
 
 jobs:
   deploy:


### PR DESCRIPTION
The `deploy-feedback-worker` workflow has never successfully run — all 3 attempts failed since it was introduced in Feb 2026. The worker has always been deployed manually from local.

Auto-deploy on push is commented out. The workflow is kept (with `workflow_dispatch` still available) so the intent is preserved, with notes on what's needed to re-enable it:
1. Restore `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in repo secrets
2. Verify the token is still active in the Cloudflare dashboard

To deploy the worker locally in the meantime: `cd worker && npx wrangler deploy`