### PR TITLE
Floating thumbs-up CTA with starburst badge

### DIFF
--- a/src/components/vf-componenet-rollup/index.scss
+++ b/src/components/vf-componenet-rollup/index.scss
@@ -1327,49 +1327,75 @@ body:has(#kh-css-toggle:checked) {
   // Composition: a promotional text card + a starburst badge with 👍.
   // Same href as the footer button (.../up/{page}); Worker redirects back to
   // #thanks, which triggers the kh-feedback-thanks toast and hides this widget.
+  // Wrapper stacks the upvote card on top and the secondary "learn" link
+  // below it, so the link reads as a separate action and can't be confused
+  // with the upvote click target.
   .kh-floating-thumb {
     position: fixed;
     z-index: 900;
     right: max(1rem, env(safe-area-inset-right));
     bottom: max(1rem, env(safe-area-inset-bottom));
     display: inline-flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.4rem;
+    color: inherit;
+    max-width: min(360px, calc(100vw - 2rem));
+  }
+
+  // The upvote action — burst + text laid out horizontally inside one anchor.
+  .kh-floating-thumb__action {
+    display: inline-flex;
     align-items: center;
     text-decoration: none;
     color: inherit;
-    max-width: min(360px, calc(100vw - 2rem));
+  }
+
+  // Secondary link below the card. Visually quieter (smaller, plain text) so
+  // it doesn't compete with the upvote CTA, but with a clear underlined hover
+  // state so it's discoverable as a separate action.
+  .kh-floating-thumb__learn {
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--kh-color--blue);
+    text-decoration: underline;
+    text-decoration-color: transparent;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 3px;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    transition: text-decoration-color 0.15s ease, color 0.15s ease, background-color 0.15s ease;
+
+    &:hover,
+    &:focus-visible {
+      color: var(--kh-color--blue--dark);
+      text-decoration-color: var(--kh-color--orange);
+      background-color: rgba(#fff, 0.7);
+    }
   }
 
   .kh-floating-thumb__text {
     display: flex;
     flex-direction: column;
     gap: 0.2rem;
-    background: #fafafa;
-    border: 2px solid var(--kh-color--blue);
-    border-left: none;
-    border-radius: 0 12px 12px 0;
-    padding: 0.65rem 0.95rem 0.65rem 2.6rem; // left padding leaves room for burst overlap
-    box-shadow: 3px 3px 0 var(--kh-color--blue--dark);
+    background: var(--kh-color--blue);
+    border-radius: 14px;
+    padding: 0.7rem 1rem 0.7rem 1.8rem; // left padding leaves room for burst overlap
+    box-shadow: 0 4px 0 var(--kh-color--orange);
   }
 
   .kh-floating-thumb__lead {
     font-weight: 700;
     font-size: 1rem;
-    color: var(--kh-color--blue);
+    color: #fff;
     line-height: 1.15;
   }
 
   .kh-floating-thumb__sub {
     font-size: 0.78rem;
     font-weight: 500;
-    color: var(--kh-color--grey--darkest);
+    color: rgba(#fff, 0.92);
     line-height: 1.35;
-  }
-
-  .kh-floating-thumb__sub-strong {
-    text-decoration: underline;
-    text-decoration-color: var(--kh-color--orange);
-    text-decoration-thickness: 2px;
-    text-underline-offset: 2px;
   }
 
   // CSS-only 12-point starburst, flat orange fill with a dark-blue stroke.
@@ -1399,19 +1425,19 @@ body:has(#kh-css-toggle:checked) {
     width: 84px;
     height: 84px;
     margin-right: -1.4rem; // overlap into the text card
-    background: var(--kh-color--blue--dark); // stroke colour
+    background: var(--kh-color--orange); // stroke colour
     clip-path: $kh-burst-clip;
     display: grid;
     place-items: center;
     transform: rotate(-8deg);
     transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
-    filter: drop-shadow(2px 3px 0 var(--kh-color--blue--dark));
+    filter: drop-shadow(0 3px 0 rgba(0, 0, 0, 0.12));
 
     &::before {
       content: "";
       position: absolute;
       inset: 3px; // stroke thickness
-      background: var(--kh-color--orange);
+      background: var(--kh-color--yellow--dark, #ffb81c);
       clip-path: $kh-burst-clip;
     }
   }
@@ -1421,22 +1447,49 @@ body:has(#kh-css-toggle:checked) {
     z-index: 1; // above the ::before inner fill
     width: 36px;
     height: 36px;
-    color: var(--kh-color--blue--dark);
+    color: #fff;
+    stroke-width: 2.2;
     transform: rotate(8deg); // counter-rotate so icon stays upright vs. tilted burst
   }
 
-  .kh-floating-thumb:hover .kh-floating-thumb__burst,
-  .kh-floating-thumb:focus-visible .kh-floating-thumb__burst {
+  // Scope the wobble to the action anchor only — moving onto the learn link
+  // unhovers the action, which lets the existing transition revert the burst.
+  .kh-floating-thumb__action:hover .kh-floating-thumb__burst,
+  .kh-floating-thumb__action:focus-visible .kh-floating-thumb__burst {
     transform: rotate(8deg) scale(1.08);
   }
 
-  .kh-floating-thumb:hover .kh-floating-thumb__icon,
-  .kh-floating-thumb:focus-visible .kh-floating-thumb__icon {
+  .kh-floating-thumb__action:hover .kh-floating-thumb__icon,
+  .kh-floating-thumb__action:focus-visible .kh-floating-thumb__icon {
     transform: rotate(-8deg);
   }
 
-  .kh-floating-thumb:active .kh-floating-thumb__burst {
-    transform: rotate(0deg) scale(0.96);
+  // While the user is clicking and the browser is round-tripping to the
+  // Cloudflare worker, spin the burst. Pure CSS: :active is held by browsers
+  // during a link's navigation phase; :focus:not(:focus-visible) extends the
+  // spin through mouse-induced focus on browsers that drop :active early.
+  // The page navigates away on click, so the state naturally clears on return.
+  .kh-floating-thumb__action:active .kh-floating-thumb__burst,
+  .kh-floating-thumb__action:focus:not(:focus-visible) .kh-floating-thumb__burst {
+    animation: kh-floating-thumb-spin 0.7s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+  }
+
+  @keyframes kh-floating-thumb-spin {
+    from {
+      transform: rotate(0deg) scale(1.05);
+    }
+
+    to {
+      transform: rotate(360deg) scale(1.05);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .kh-floating-thumb__action:active .kh-floating-thumb__burst,
+    .kh-floating-thumb__action:focus:not(:focus-visible) .kh-floating-thumb__burst {
+      animation: none;
+      transform: rotate(-8deg) scale(0.96);
+    }
   }
 
   // Mobile: drop the text card; the starburst is the playful, tappable bit.

--- a/src/components/vf-componenet-rollup/index.scss
+++ b/src/components/vf-componenet-rollup/index.scss
@@ -1364,7 +1364,7 @@ body:has(#kh-css-toggle:checked) {
     text-underline-offset: 3px;
     padding: 0.2rem 0.4rem;
     border-radius: 4px;
-    transition: text-decoration-color 0.15s ease, color 0.15s ease, background-color 0.15s ease;
+    transition: text-decoration-color 0.15s ease, color 0.15s ease, background-color 0.15s ease, transform 0.15s ease;
 
     &:hover,
     &:focus-visible {
@@ -1372,6 +1372,11 @@ body:has(#kh-css-toggle:checked) {
       text-decoration-color: var(--kh-color--orange);
       background-color: rgba(#fff, 0.7);
     }
+  }
+
+  // Default (desktop): show the long text, hide the icon.
+  .kh-floating-thumb__learn-icon {
+    display: none;
   }
 
   .kh-floating-thumb__text {
@@ -1493,7 +1498,8 @@ body:has(#kh-css-toggle:checked) {
   }
 
   // Mobile: drop the text card; the starburst is the playful, tappable bit.
-  // Keeps the bottom-right corner uncluttered on phones; aria-label covers a11y.
+  // The "Learn about..." link collapses to a small circular "?" badge so it
+  // doesn't dominate the bottom-right corner. Keeps a11y via aria-label.
   @media (max-width: 600px) {
     .kh-floating-thumb__text {
       display: none;
@@ -1508,6 +1514,40 @@ body:has(#kh-css-toggle:checked) {
     .kh-floating-thumb__icon {
       width: 30px;
       height: 30px;
+    }
+
+    .kh-floating-thumb__learn-text {
+      display: none;
+    }
+
+    .kh-floating-thumb__learn {
+      position: relative;
+      z-index: 2; // sit above the burst's drop shadow + clipped fill
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      margin-top: -2.15rem; // tuck up so it overlaps the burst's lower-right spike
+      padding: 0;
+      border: 2px solid var(--kh-color--blue);
+      border-radius: 999px;
+      background: #fafafa;
+      text-decoration: none;
+      font-weight: 700;
+      line-height: 1;
+
+      &:hover,
+      &:focus-visible {
+        background: var(--kh-color--blue);
+        color: #fff;
+        text-decoration: none;
+      }
+    }
+
+    .kh-floating-thumb__learn-icon {
+      display: inline-block;
+      font-size: 0.95rem;
     }
   }
 

--- a/src/components/vf-componenet-rollup/index.scss
+++ b/src/components/vf-componenet-rollup/index.scss
@@ -1315,6 +1315,155 @@ body:has(#kh-css-toggle:checked) {
     }
   }
 
+  // Inline thanks-link inside the feedback toast — small follow-up CTA
+  .kh-feedback-thanks__link {
+    margin-left: 0.5rem;
+    font-weight: 500;
+    text-decoration: underline;
+    color: inherit;
+  }
+
+  // Floating "was this helpful?" thumb — bottom-right, no JS, no count.
+  // Composition: a promotional text card + a starburst badge with 👍.
+  // Same href as the footer button (.../up/{page}); Worker redirects back to
+  // #thanks, which triggers the kh-feedback-thanks toast and hides this widget.
+  .kh-floating-thumb {
+    position: fixed;
+    z-index: 900;
+    right: max(1rem, env(safe-area-inset-right));
+    bottom: max(1rem, env(safe-area-inset-bottom));
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
+    color: inherit;
+    max-width: min(360px, calc(100vw - 2rem));
+  }
+
+  .kh-floating-thumb__text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    background: #fafafa;
+    border: 2px solid var(--kh-color--blue);
+    border-left: none;
+    border-radius: 0 12px 12px 0;
+    padding: 0.65rem 0.95rem 0.65rem 2.6rem; // left padding leaves room for burst overlap
+    box-shadow: 3px 3px 0 var(--kh-color--blue--dark);
+  }
+
+  .kh-floating-thumb__lead {
+    font-weight: 700;
+    font-size: 1rem;
+    color: var(--kh-color--blue);
+    line-height: 1.15;
+  }
+
+  .kh-floating-thumb__sub {
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--kh-color--grey--darkest);
+    line-height: 1.35;
+  }
+
+  .kh-floating-thumb__sub-strong {
+    text-decoration: underline;
+    text-decoration-color: var(--kh-color--orange);
+    text-decoration-thickness: 2px;
+    text-underline-offset: 2px;
+  }
+
+  // CSS-only 12-point starburst, flat orange fill with a dark-blue stroke.
+  // The stroke is faked by stacking two clipped layers: the burst element
+  // is filled in the stroke colour, and ::before is inset by the stroke
+  // width and re-clipped with the same polygon to reveal the inner fill.
+  // clip-path polygon points alternate outer (50%) and inner (35%) radius.
+  $kh-burst-clip: polygon(
+    50% 0%, 59.06% 16.19%,
+    75% 6.7%, 74.75% 25.25%,
+    93.3% 25%, 83.81% 40.94%,
+    100% 50%, 83.81% 59.06%,
+    93.3% 75%, 74.75% 74.75%,
+    75% 93.3%, 59.06% 83.81%,
+    50% 100%, 40.94% 83.81%,
+    25% 93.3%, 25.25% 74.75%,
+    6.7% 75%, 16.19% 59.06%,
+    0% 50%, 16.19% 40.94%,
+    6.7% 25%, 25.25% 25.25%,
+    25% 6.7%, 40.94% 16.19%
+  );
+
+  .kh-floating-thumb__burst {
+    position: relative;
+    z-index: 1; // sit above text card so the star edges poke over the border
+    flex: 0 0 auto;
+    width: 84px;
+    height: 84px;
+    margin-right: -1.4rem; // overlap into the text card
+    background: var(--kh-color--blue--dark); // stroke colour
+    clip-path: $kh-burst-clip;
+    display: grid;
+    place-items: center;
+    transform: rotate(-8deg);
+    transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+    filter: drop-shadow(2px 3px 0 var(--kh-color--blue--dark));
+
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 3px; // stroke thickness
+      background: var(--kh-color--orange);
+      clip-path: $kh-burst-clip;
+    }
+  }
+
+  .kh-floating-thumb__icon {
+    position: relative;
+    z-index: 1; // above the ::before inner fill
+    width: 36px;
+    height: 36px;
+    color: var(--kh-color--blue--dark);
+    transform: rotate(8deg); // counter-rotate so icon stays upright vs. tilted burst
+  }
+
+  .kh-floating-thumb:hover .kh-floating-thumb__burst,
+  .kh-floating-thumb:focus-visible .kh-floating-thumb__burst {
+    transform: rotate(8deg) scale(1.08);
+  }
+
+  .kh-floating-thumb:hover .kh-floating-thumb__icon,
+  .kh-floating-thumb:focus-visible .kh-floating-thumb__icon {
+    transform: rotate(-8deg);
+  }
+
+  .kh-floating-thumb:active .kh-floating-thumb__burst {
+    transform: rotate(0deg) scale(0.96);
+  }
+
+  // Mobile: drop the text card; the starburst is the playful, tappable bit.
+  // Keeps the bottom-right corner uncluttered on phones; aria-label covers a11y.
+  @media (max-width: 600px) {
+    .kh-floating-thumb__text {
+      display: none;
+    }
+
+    .kh-floating-thumb__burst {
+      margin-right: 0;
+      width: 72px;
+      height: 72px;
+    }
+
+    .kh-floating-thumb__icon {
+      width: 30px;
+      height: 30px;
+    }
+  }
+
+  // Once the user has clicked (URL has #thanks), hide the floating widget so
+  // it doesn't pester them. The kh-feedback-thanks toast covers the confirmation.
+  &:has(#thanks:target) .kh-floating-thumb {
+    display: none;
+  }
+
   .kh-details {
     border: 4px solid var(--kh-color--blue);
     border-radius: 4px;

--- a/src/site/_includes/layouts/post.njk
+++ b/src/site/_includes/layouts/post.njk
@@ -104,7 +104,7 @@ templateEngineOverride: njk
           <a href="https://feedback.allaboutken.com/up{{ page.url }}"
             rel="nofollow" class="kh-button kh-button--sm">👍 This was useful</a>
         <!-- Feedback toast: see /posts/20260220-feedback-buttons-cgi-pattern/ -->
-        <span id="thanks" class="kh-feedback-thanks" aria-live="polite">Thanks for the feedback!</span>
+        <span id="thanks" class="kh-feedback-thanks" aria-live="polite">Thanks for the feedback! <a href="/posts/20260220-feedback-buttons-cgi-pattern/" class="kh-feedback-thanks__link">Curious how this was built?</a></span>
         <span><img src="https://feedback.allaboutken.com/count{{ page.url }}.svg" alt="Feedback count" style="display:inline;vertical-align:middle;height:1.5em;max-width:none"> people found this useful</span>
         </p>
       </div>
@@ -135,3 +135,20 @@ templateEngineOverride: njk
   </article>
   {%- endif %}
 </div>
+
+{%- if comment != false %}
+<a href="https://feedback.allaboutken.com/up{{ page.url }}"
+   rel="nofollow"
+   class="kh-floating-thumb kh-u-do-not-print"
+   aria-label="This was helpful — give a thumbs up.">
+  <span class="kh-floating-thumb__burst" aria-hidden="true">
+    {# Thumbs-up icon from Lucide — https://lucide.dev/icons/thumbs-up #}
+    <!-- Thumbs-up icon: Lucide (https://lucide.dev/icons/thumbs-up) -->
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="kh-floating-thumb__icon" aria-hidden="true" focusable="false"><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/><path d="M7 10v12"/></svg>
+  </span>
+  <span class="kh-floating-thumb__text">
+    <span class="kh-floating-thumb__lead">This was helpful</span>
+    <span class="kh-floating-thumb__sub">Let me know if this was helpful. <span class="kh-floating-thumb__sub-strong">Learn more about this JS-free technique.</span></span>
+  </span>
+</a>
+{%- endif %}

--- a/src/site/_includes/layouts/post.njk
+++ b/src/site/_includes/layouts/post.njk
@@ -151,6 +151,9 @@ templateEngineOverride: njk
       <span class="kh-floating-thumb__sub">Tap to tell me if so.</span>
     </span>
   </a>
-  <a href="/posts/20260220-feedback-buttons-cgi-pattern/" class="kh-floating-thumb__learn">Learn about this JS-free technique →</a>
+  <a href="/posts/20260220-feedback-buttons-cgi-pattern/" class="kh-floating-thumb__learn" aria-label="Learn about this JS-free technique">
+    <span class="kh-floating-thumb__learn-text" aria-hidden="true">Learn about this JS-free technique →</span>
+    <span class="kh-floating-thumb__learn-icon" aria-hidden="true">?</span>
+  </a>
 </div>
 {%- endif %}

--- a/src/site/_includes/layouts/post.njk
+++ b/src/site/_includes/layouts/post.njk
@@ -137,18 +137,20 @@ templateEngineOverride: njk
 </div>
 
 {%- if comment != false %}
-<a href="https://feedback.allaboutken.com/up{{ page.url }}"
-   rel="nofollow"
-   class="kh-floating-thumb kh-u-do-not-print"
-   aria-label="This was helpful — give a thumbs up.">
-  <span class="kh-floating-thumb__burst" aria-hidden="true">
-    {# Thumbs-up icon from Lucide — https://lucide.dev/icons/thumbs-up #}
-    <!-- Thumbs-up icon: Lucide (https://lucide.dev/icons/thumbs-up) -->
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="kh-floating-thumb__icon" aria-hidden="true" focusable="false"><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/><path d="M7 10v12"/></svg>
-  </span>
-  <span class="kh-floating-thumb__text">
-    <span class="kh-floating-thumb__lead">This was helpful</span>
-    <span class="kh-floating-thumb__sub">Let me know if this was helpful. <span class="kh-floating-thumb__sub-strong">Learn more about this JS-free technique.</span></span>
-  </span>
-</a>
+<div class="kh-floating-thumb kh-u-do-not-print">
+  <a href="https://feedback.allaboutken.com/up{{ page.url }}"
+     rel="nofollow"
+     class="kh-floating-thumb__action">
+    <span class="kh-floating-thumb__burst" aria-hidden="true">
+      {# Thumbs-up icon from Lucide — https://lucide.dev/icons/thumbs-up #}
+      <!-- Thumbs-up icon: Lucide (https://lucide.dev/icons/thumbs-up) -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="kh-floating-thumb__icon" aria-hidden="true" focusable="false"><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/><path d="M7 10v12"/></svg>
+    </span>
+    <span class="kh-floating-thumb__text">
+      <span class="kh-floating-thumb__lead">Was this helpful?</span>
+      <span class="kh-floating-thumb__sub">Tap to tell me if so.</span>
+    </span>
+  </a>
+  <a href="/posts/20260220-feedback-buttons-cgi-pattern/" class="kh-floating-thumb__learn">Learn about this JS-free technique →</a>
+</div>
 {%- endif %}


### PR DESCRIPTION
Closes #54.

## Summary

- Adds a fixed bottom-right "This was helpful" widget on every blog post: a CSS starburst (12-point `clip-path` polygon, flat orange fill, faked dark-blue stroke via an inset `::before`) holding the Lucide thumbs-up SVG, paired with a promo card.
- Promo card copy: **This was helpful** / _Let me know if this was helpful._ <ins>Learn more about this JS-free technique.</ins>
- Reuses the existing `feedback.allaboutken.com/up{page.url}` Worker endpoint — no new JS, no new backend. The Worker still 302-redirects back to `#thanks`, and `:has(#thanks:target)` hides the floating widget so the existing `kh-feedback-thanks` toast covers the confirmation.
- Toast text now ends with a "Curious how this was built?" link to `/posts/20260220-feedback-buttons-cgi-pattern/`.
- Mobile (≤ 600px): drops the promo card and shows just the badge; `aria-label` carries the meaning for screen readers.
- Marked `kh-u-do-not-print` so it doesn't appear on printed pages.
- Lucide icon credited inline via an HTML comment (`<!-- Thumbs-up icon: Lucide (https://lucide.dev/icons/thumbs-up) -->`).

## Files

- `src/site/_includes/layouts/post.njk` — new floating widget markup, extended thanks-toast copy.
- `src/components/vf-componenet-rollup/index.scss` — `.kh-floating-thumb*` styles + starburst clip-path + stroke layering.

## Test plan

- [ ] `yarn dev` — load any blog post, confirm the badge appears bottom-right and the promo card sits to the right of it on desktop.
- [ ] Click the widget → page returns with `#thanks` → existing toast appears with the new "Curious how this was built?" link → floating widget is hidden.
- [ ] Resize to ≤ 600px — promo card hides, only the badge remains; tap target ≥ 44px.
- [ ] Hover/focus — burst wobbles, icon counter-rotates; `:focus-visible` ring is visible.
- [ ] Print preview — widget is omitted (`kh-u-do-not-print`).
- [ ] CSS-toggle off (uncheck `#kh-css-toggle`) — widget gracefully unstyled (intentional, scoped under the toggle).
- [ ] Visual: confirm the uneven CSS stroke on the starburst still reads as a charming comic outline (otherwise swap to inline SVG `<polygon stroke>` in a follow-up).

## Out of scope

- No changes to the footer button or the count display.
- No Worker changes — same endpoint and redirect target.