### PR TITLE
content: launch garage page and document Vercel project proxy

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Enforces the commit message convention: <prefix>: <description>
+# See CONTRIBUTING.md for the full list of prefixes.
+
+commit_msg=$(cat "$1")
+
+# Skip merge, revert, and fixup commits — they're machine-generated
+if echo "$commit_msg" | grep -qE "^(Merge |Revert |fixup! |squash! )"; then
+  exit 0
+fi
+
+pattern="^(content|feature|fix|ci|chore): .+"
+
+if ! echo "$commit_msg" | grep -qE "$pattern"; then
+  echo ""
+  echo "  ❌  Commit message format error"
+  echo ""
+  echo "  Expected:  <prefix>: <description>"
+  echo "  Prefixes:  content | feature | fix | ci | chore"
+  echo ""
+  echo "  Got:  $commit_msg"
+  echo ""
+  exit 1
+fi

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,25 @@
+name: PR title check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title matches commit convention
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if echo "$PR_TITLE" | grep -qE "^(content|feature|fix|ci|chore): .+"; then
+            echo "✅ PR title OK: $PR_TITLE"
+          else
+            echo "❌ PR title must match the commit convention"
+            echo ""
+            echo "   Expected:  <prefix>: <description>"
+            echo "   Prefixes:  content | feature | fix | ci | chore"
+            echo ""
+            echo "   Got:  $PR_TITLE"
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,31 +18,24 @@ One branch per unit of work. If a content post and an unrelated refactor ship to
 
 ## Commit messages
 
-A hybrid convention: sentence-case verb-first for content and features; conventional-commits prefixes for deps, fixes, and infra.
+Format: `prefix: sentence-case description`
 
-### Content
+| Prefix | Use for |
+|--------|---------|
+| `content:` | Posts, pages, editorial copy, images |
+| `feature:` | New site functionality or pages |
+| `fix:` | Bug fixes, broken builds, broken links |
+| `ci:` | GitHub Actions, Vercel config, deployment |
+| `chore:` | Deps, tooling, refactoring, procedural docs |
 
-- `Add post: <title>`
-- `Add digest post: <title>` (for `/digesting` entries)
-- `Update post: <title>`
-- `Draft: <title>` (for WIP commits on a draft branch)
+Examples:
 
-### Features and structural changes
-
-Verb-first imperative, sentence case. Examples from the log:
-
-- `Paginate blog index, add search boxes`
-- `Extract post-summary and pager partials`
-- `Unify search form layout with inline icon button`
-
-### Dependencies, tooling, infra
-
-Conventional-commits prefix:
-
-- `chore: upgrade pagefind 1.4.0 → 1.5.2`
-- `chore(deps): bump sass in the minor-and-patch group`
-- `chore: add CONTRIBUTING.md and PR template` (procedural docs)
-- `fix: add z-index to margin notes for stacking context`
+- `content: Add garage page intro and how-it-works section`
+- `content: Draft post on Vercel proxy for hobby projects`
+- `feature: Add /garage/ index page and data file`
+- `fix: Correct trailing-slash redirect for proxied paths`
+- `ci: Add pinment rewrite and CORS headers to vercel.json`
+- `chore: Upgrade pagefind 1.4.0 → 1.5.2`
 
 ### General rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,8 @@ Examples:
 - One logical change per commit
 - Never use `--no-verify` or `--no-gpg-sign` to bypass hooks
 
+The format is enforced locally by `.githooks/commit-msg` (activated on `yarn install` via the `prepare` script) and on PRs by the `pr-title-check` GitHub Actions workflow.
+
 ## Pull requests
 
 One PR per unit of work. Keep noisy refactors out of content PRs.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dev": "concurrently -k \"sass --load-path src/components --watch src/components/vf-componenet-rollup/index.scss:build/css/styles.css\" \"ELEVENTY_ENV=development eleventy --serve --config=eleventy.js\"",
     "start": "yarn dev",
     "test": "echo \"Error: no test specified\" && exit 0",
+    "prepare": "git config core.hooksPath .githooks",
     "update-components": "yarn upgrade-interactive --latest"
   },
   "dependencies": {

--- a/src/components/vf-componenet-rollup/_kh-content.scss
+++ b/src/components/vf-componenet-rollup/_kh-content.scss
@@ -39,8 +39,6 @@
   }
 
   blockquote:not([class*='kh-']) {
-    border: 0;
-    color: #222;
     font-weight: 400;
     margin: 0 0 16px;
     padding: 10px 8px 10px 32px;

--- a/src/components/vf-componenet-rollup/normalize.scss
+++ b/src/components/vf-componenet-rollup/normalize.scss
@@ -54,7 +54,7 @@
   [type='button'],
   [type='reset'],
   [type='submit'] {
-    appearance: button;
+    appearance: auto;
     -webkit-appearance: button;
   }
 

--- a/src/site/_data/garage.json
+++ b/src/site/_data/garage.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "PDF-A-go-go",
+    "path": "/PDF-A-go-go/",
+    "repo": "https://github.com/khawkins98/PDF-A-go-go",
+    "post": "/posts/20250811-pdf-a-go-go/",
+    "status": "stable",
+    "description": "A lightweight embeddable PDF viewer for the web. Drop it into any static site without a server or a third-party service."
+  },
+  {
+    "name": "pinment",
+    "path": "/pinment/",
+    "repo": "https://github.com/khawkins98/pinment",
+    "post": "/posts/20260225-introducing-pinment/",
+    "status": "active",
+    "description": "A browser bookmarklet for pinning comments to a live webpage and sharing the annotations as a single URL. No backend, no accounts."
+  }
+]

--- a/src/site/_data/garage.json
+++ b/src/site/_data/garage.json
@@ -5,14 +5,18 @@
     "repo": "https://github.com/khawkins98/PDF-A-go-go",
     "post": "/posts/20250811-pdf-a-go-go/",
     "status": "stable",
-    "description": "A lightweight embeddable PDF viewer for the web. Drop it into any static site without a server or a third-party service."
+    "description": "A lightweight embeddable PDF viewer for the web. Drop it into any static site without a server or a third-party service.",
+    "image": "/blog/pdf-a-go-go.jpg",
+    "image_alt": "A modern, accessible PDF viewer interface."
   },
   {
-    "name": "pinment",
+    "name": "Pinment",
     "path": "/pinment/",
     "repo": "https://github.com/khawkins98/pinment",
     "post": "/posts/20260225-introducing-pinment/",
     "status": "active",
-    "description": "A browser bookmarklet for pinning comments to a live webpage and sharing the annotations as a single URL. No backend, no accounts."
+    "description": "A browser bookmarklet for pinning comments to a live webpage and sharing the annotations as a single URL. No backend, no accounts.",
+    "image": "/blog/pinment-share-modal.jpg",
+    "image_alt": "Pinment startup modal overlaying a webpage, showing options to start annotating, paste a share URL, or import from JSON."
   }
 ]

--- a/src/site/garage.njk
+++ b/src/site/garage.njk
@@ -24,13 +24,10 @@ permalink: /garage/
   <div class="kh-content">
 
 {% markdown %}
-I'm Ken. Most of my work involves [helping complex organisations turn their digital presence into systems that actually do something](/), and a lot of that work is coordination: meetings, decisions, aligning people, and some code that makes the pieces real. I often find myself building little tools on the side when an idea appears or a small problem keeps repeating: programs, widgets, utilities, experiments. Things that scratch a professional itch, help me and colleagues get something done, or just exist because the idea was interesting enough to build.
+Most of my work involves [helping complex organisations turn their digital presence into systems that actually do something](/), and a lot of that work is coordination: meetings, decisions, aligning people, and some code that makes the pieces real. I often find myself building little tools on the side when an idea appears or a small problem keeps repeating: programs, widgets, utilities, experiments. Things that scratch an itch or curiosity, and help me and colleagues get something done, or just exist because the idea was interesting enough to build.
 
-This is the garage. A place to collect the ones I can share and that are worth pointing people at. Not everything makes it here -- some projects are tied to paid work and can't be made public, others are too rough or too personal to be useful to anyone else. The ones below are the ones that are at least dog-fooded to my own use case: things I actually reach for, or did at some point, because they solved a real problem for me.
+This is my "virtual garage". Not everything makes it here -- some projects are tied to paid work and can't be made public, others are too rough or not yet there, or sometimes just not yet added.
 
-They won't always be stable, polished, or pretty. That's the nature of tinkering. But they're genuine -- and if any of them turn out to be useful to you too, that's a bonus.
-
-All of these are on [GitHub](https://github.com/khawkins98) for now, but that's not a permanent requirement. The garage is the canonical home.
 {% endmarkdown %}
 
 <section class="kh-card-container kh-u-margin__top--800">
@@ -40,6 +37,11 @@ All of these are on [GitHub](https://github.com/khawkins98) for now, but that's 
   <h2 class="kh-summary__title kh-font-headline">
     <a href="{{ project.path }}" class="kh-summary__link">{{ project.name }}</a>
   </h2>
+  {% if project.image %}
+  <a href="{{ project.path }}" class="kh-summary__image">
+    <img src="/images{{ project.image }}" alt="{{ project.image_alt or project.name }}">
+  </a>
+  {% endif %}
   <p class="kh-summary__text">{{ project.description }}</p>
   <p class="kh-cluster">
     <a href="{{ project.post }}">Read the post</a>
@@ -50,17 +52,14 @@ All of these are on [GitHub](https://github.com/khawkins98) for now, but that's 
 </section>
 
 {% markdown %}
-Only two projects are here so far -- I'm bringing them across carefully to make sure existing embed links don't break in the process. For the full list of what I've built, [GitHub has everything](https://github.com/khawkins98?tab=repositories).
+Only two of [my projects](https://github.com/khawkins98?tab=repositories) are here so far. I've just done this in May 2026 and am letting it stew for a couple of weeks before bringing more across.
 {% endmarkdown %}
 
 {% markdown %}
----
 
 ### How this works
 
-Each project lives in its own GitHub repository and deploys independently to [GitHub Pages](https://pages.github.com/). On the allaboutken.com side, a [Vercel rewrites](https://vercel.com/docs/edge-network/rewrites) block in `vercel.json` reverse-proxies each path prefix to its corresponding GitHub Pages URL -- so `/PDF-A-go-go/` here is actually serving `khawkins98.github.io/PDF-A-go-go/` behind the scenes.
-
-The garage page itself is data-driven: a JSON file lists the projects, Eleventy renders this page from it, and adding a new project means one entry in that file plus one line in `vercel.json`. The full story is in [the blog post](/posts/20260509-vercel-proxy-hobby-projects/).
+This page is rendered from [`src/site/_data/garage.json`](https://github.com/khawkins98/allaboutken-11ty/blob/main/src/site/_data/garage.json): I add a JSON entry plus a rewrite line for each GitHub Pages project. The full details are in [the blog post](/posts/20260509-vercel-proxy-hobby-projects/).
 {% endmarkdown %}
 
   </div>

--- a/src/site/garage.njk
+++ b/src/site/garage.njk
@@ -24,7 +24,7 @@ permalink: /garage/
   <div class="kh-content">
 
 {% markdown %}
-I'm Ken. Most of my work involves [helping complex organisations turn their digital presence into systems that actually do something](/) -- the kind of work that lives in pull requests, architecture documents, and other people's repos. But I've increasingly found myself building things on the side: small programs, widgets, utilities, experiments. Things that scratch a professional itch, help me and colleagues get something done, or just exist because the idea was interesting enough to build.
+I'm Ken. Most of my work involves [helping complex organisations turn their digital presence into systems that actually do something](/), and a lot of that work is coordination: meetings, decisions, aligning people, and some code that makes the pieces real. I often find myself building little tools on the side when an idea appears or a small problem keeps repeating: programs, widgets, utilities, experiments. Things that scratch a professional itch, help me and colleagues get something done, or just exist because the idea was interesting enough to build.
 
 This is the garage. A place to collect the ones I can share and that are worth pointing people at. Not everything makes it here -- some projects are tied to paid work and can't be made public, others are too rough or too personal to be useful to anyone else. The ones below are the ones that are at least dog-fooded to my own use case: things I actually reach for, or did at some point, because they solved a real problem for me.
 
@@ -33,9 +33,9 @@ They won't always be stable, polished, or pretty. That's the nature of tinkering
 All of these are on [GitHub](https://github.com/khawkins98) for now, but that's not a permanent requirement. The garage is the canonical home.
 {% endmarkdown %}
 
-<section class="kh-u-margin__top--800">
+<section class="kh-card-container kh-u-margin__top--800">
 {% for project in garage %}
-<article class="kh-summary kh-summary--news kh-u-margin__bottom--600">
+<article class="kh-summary kh-summary--news kh-summary--highlight kh-u-margin__bottom--600">
   <div class="kh-summary__date"><span class="kh-label">{{ project.status }}</span></div>
   <h2 class="kh-summary__title kh-font-headline">
     <a href="{{ project.path }}" class="kh-summary__link">{{ project.name }}</a>
@@ -48,6 +48,10 @@ All of these are on [GitHub](https://github.com/khawkins98) for now, but that's 
 </article>
 {% endfor %}
 </section>
+
+{% markdown %}
+Only two projects are here so far -- I'm bringing them across carefully to make sure existing embed links don't break in the process. For the full list of what I've built, [GitHub has everything](https://github.com/khawkins98?tab=repositories).
+{% endmarkdown %}
 
 {% markdown %}
 ---

--- a/src/site/garage.njk
+++ b/src/site/garage.njk
@@ -1,0 +1,50 @@
+---
+title: The garage
+layout: layouts/base.njk
+date: 2026-05-09
+lastUpdated: 2026-05-09
+templateEngineOverride: njk
+permalink: /garage/
+---
+
+<article class="kh-grid-stylized kh-u-margin__top--1200">
+  <div></div>
+  <div class="kh-content">
+    <h1 class="kh-font-headline kh-text-heading--1">{{ title }}</h1>
+
+{% markdown %}
+I'm Ken -- I build things professionally for a living, and I build things for fun in whatever time is left. This is the garage: a place to collect the hobby projects worth showing off, all under one roof.
+
+Not every experiment makes it here. Some repos stay quietly on [GitHub](https://github.com/khawkins98) because they're unfinished or only interesting to me. The ones below are the projects I want to point people at -- things that actually work, that I might still tinker with, and that I'm happy to explain if you ask.
+
+These projects aren't necessarily on GitHub forever either. The garage is the canonical home; GitHub is just where the code lives right now.
+{% endmarkdown %}
+
+<ul class="kh-u-list-plain kh-u-margin__top--800">
+{% for project in garage %}
+<li class="kh-u-margin__bottom--900" style="border-top: 1px solid var(--kh-color--grey-light, #e0e0e0); padding-top: 1.5rem;">
+  <h2 class="kh-text-heading--2 kh-u-margin__bottom--300">
+    <a href="{{ project.path }}">{{ project.name }}</a>
+    <span class="kh-label kh-u-margin__left--200">{{ project.status }}</span>
+  </h2>
+  <p>{{ project.description }}</p>
+  <p class="kh-u-text--small">
+    <a href="{{ project.post }}">Read the post</a> &middot;
+    <a href="{{ project.repo }}">Source on GitHub</a>
+  </p>
+</li>
+{% endfor %}
+</ul>
+
+{% markdown %}
+---
+
+### How this works
+
+Each project lives in its own GitHub repository and deploys independently to [GitHub Pages](https://pages.github.com/). On the allaboutken.com side, a [Vercel rewrites](https://vercel.com/docs/edge-network/rewrites) block in `vercel.json` reverse-proxies each path prefix to its corresponding GitHub Pages URL -- so `/PDF-A-go-go/` here is actually serving `khawkins98.github.io/PDF-A-go-go/` behind the scenes.
+
+The garage page itself is data-driven: a JSON file lists the projects, Eleventy renders this page from it, and adding a new project means one entry in that file plus one line in `vercel.json`. The full story is in [the blog post](/posts/20260509-vercel-proxy-hobby-projects/).
+{% endmarkdown %}
+
+  </div>
+</article>

--- a/src/site/garage.njk
+++ b/src/site/garage.njk
@@ -7,34 +7,47 @@ templateEngineOverride: njk
 permalink: /garage/
 ---
 
+<div class="kh-u-background-color--yellow--dark kh-u-fullbleed">
+  <section class="kh-grid-stylized kh-u-padding__top--500 kh-u-padding__bottom--500">
+    <div></div>
+    <div class="kh-content">
+      <h1 class="kh-font-headline kh-text-heading--1">
+        <div class="kh-font-headline--display">The garage.</div>
+      </h1>
+      <p class="kh-text-heading--2">Side projects, utilities, and experiments worth sharing.</p>
+    </div>
+  </section>
+</div>
+
 <article class="kh-grid-stylized kh-u-margin__top--1200">
   <div></div>
   <div class="kh-content">
-    <h1 class="kh-font-headline kh-text-heading--1">{{ title }}</h1>
 
 {% markdown %}
-I'm Ken -- I build things professionally for a living, and I build things for fun in whatever time is left. This is the garage: a place to collect the hobby projects worth showing off, all under one roof.
+I'm Ken. Most of my work involves [helping complex organisations turn their digital presence into systems that actually do something](/) -- the kind of work that lives in pull requests, architecture documents, and other people's repos. But I've increasingly found myself building things on the side: small programs, widgets, utilities, experiments. Things that scratch a professional itch, help me and colleagues get something done, or just exist because the idea was interesting enough to build.
 
-Not every experiment makes it here. Some repos stay quietly on [GitHub](https://github.com/khawkins98) because they're unfinished or only interesting to me. The ones below are the projects I want to point people at -- things that actually work, that I might still tinker with, and that I'm happy to explain if you ask.
+This is the garage. A place to collect the ones I can share and that are worth pointing people at. Not everything makes it here -- some projects are tied to paid work and can't be made public, others are too rough or too personal to be useful to anyone else. The ones below are the ones that are at least dog-fooded to my own use case: things I actually reach for, or did at some point, because they solved a real problem for me.
 
-These projects aren't necessarily on GitHub forever either. The garage is the canonical home; GitHub is just where the code lives right now.
+They won't always be stable, polished, or pretty. That's the nature of tinkering. But they're genuine -- and if any of them turn out to be useful to you too, that's a bonus.
+
+All of these are on [GitHub](https://github.com/khawkins98) for now, but that's not a permanent requirement. The garage is the canonical home.
 {% endmarkdown %}
 
-<ul class="kh-u-list-plain kh-u-margin__top--800">
+<section class="kh-u-margin__top--800">
 {% for project in garage %}
-<li class="kh-u-margin__bottom--900" style="border-top: 1px solid var(--kh-color--grey-light, #e0e0e0); padding-top: 1.5rem;">
-  <h2 class="kh-text-heading--2 kh-u-margin__bottom--300">
-    <a href="{{ project.path }}">{{ project.name }}</a>
-    <span class="kh-label kh-u-margin__left--200">{{ project.status }}</span>
+<article class="kh-summary kh-summary--news kh-u-margin__bottom--600">
+  <div class="kh-summary__date"><span class="kh-label">{{ project.status }}</span></div>
+  <h2 class="kh-summary__title kh-font-headline">
+    <a href="{{ project.path }}" class="kh-summary__link">{{ project.name }}</a>
   </h2>
-  <p>{{ project.description }}</p>
-  <p class="kh-u-text--small">
-    <a href="{{ project.post }}">Read the post</a> &middot;
+  <p class="kh-summary__text">{{ project.description }}</p>
+  <p class="kh-cluster">
+    <a href="{{ project.post }}">Read the post</a>
     <a href="{{ project.repo }}">Source on GitHub</a>
   </p>
-</li>
+</article>
 {% endfor %}
-</ul>
+</section>
 
 {% markdown %}
 ---

--- a/src/site/posts/20260509-vercel-proxy-hobby-projects.njk
+++ b/src/site/posts/20260509-vercel-proxy-hobby-projects.njk
@@ -1,7 +1,7 @@
 ---
 title: "Building a virtual garage for hobby projects"
 layout: layouts/post.njk
-teaser: "I wanted to bring my GitHub Pages hobby projects onto this site witout a complicated workflow, Vercel rewrites to the rescue."
+teaser: "I wanted my GitHub Pages hobby projects on-domain without a complicated workflow; Vercel rewrites turned out to be the cleanest path."
 date: 2026-05-09
 tags:
   - posts
@@ -17,9 +17,20 @@ kens_status: published
 
 I've been building hobby projects for years. Normally I'll give the better ones a write-up here and a link to GitHub Pages, but the project itself lives at `khawkins98.github.io/project-name/`.
 
-I wanted to bring them on-domain without the obvious headaches: dozens of subdomains is more infrastructure than any of these deserve, subdomains stillconfuse many people, and copying build output into the main repo defeats the point of keeping them separate.
+I wanted to bring them on-domain without the obvious headaches: dozens of subdomains is more infrastructure than any of these deserve, subdomains still confuse people, and copying build output into the main repo defeats the point of keeping them separate.
 
-Could I just have my site do it like GitHub Pages? ... proxy `/repo-name/` to whatever GitHub is already serving?
+Could I just have my site do what GitHub Pages already does: proxy `/repo-name/` to whatever GitHub is already serving?
+
+- Before: `khawkins98.github.io/PDF-A-go-go`
+- After: `AllAboutKen.com/PDF-A-go-go`
+
+Same project, same deploy pipeline, better home.
+
+<p>
+  <a href="/garage/" class="kh-button">See the garage</a>
+</p>
+
+Keep reading if you want to see exactly how I wired it up.
 
 > ## tl;dr
 >
@@ -35,9 +46,9 @@ The obvious path is a merge: monorepo, or move each project to Vercel as a separ
 
 ## How the proxy works
 
-My site was already on Vercel and each project already served from a `https://khawkins98.github.io/repo-name/`.
+My site was already on Vercel and each project already served from `https://khawkins98.github.io/repo-name/`.
 
-Then I used Vercel `rewrite` proxies a path prefix to any external origin. Minimum viable `vercel.json`:
+Vercel `rewrite` rules can proxy a path prefix to an external origin. Minimum viable `vercel.json`:
 
 ```json
 {
@@ -143,6 +154,6 @@ For SPAs with client-side routing: the project needs a `404.html` on GitHub Page
 
 The full configuration and checklist live in [`vercel.json`](https://github.com/khawkins98/allaboutken-11ty/blob/main/vercel.json) and [`docs/DEPLOYMENT.md`](https://github.com/khawkins98/allaboutken-11ty/blob/main/docs/DEPLOYMENT.md). Nothing about the project deploys has to change: GitHub Pages stays the origin, Vercel becomes the routing layer. See what it looks like in practice at the [garage](/garage/). If you've proxied projects this way — or found a cleaner approach — I'd be glad to hear about it. The projects just get to live at home.
 
-I think this is a fairly clean way to bring my web projects back "home" without the server compexities.
+I think this is a clean way to bring web projects back home without adding server complexity.
 
 {% endmarkdown %}

--- a/src/site/posts/20260509-vercel-proxy-hobby-projects.njk
+++ b/src/site/posts/20260509-vercel-proxy-hobby-projects.njk
@@ -1,7 +1,7 @@
 ---
-title: "Building a garage for hobby projects on your personal site"
+title: "Building a virtual garage for hobby projects"
 layout: layouts/post.njk
-teaser: "Years of GitHub Pages hobby projects scattered across a subdomain I don't own; Vercel rewrites brought them home without touching a deploy pipeline."
+teaser: "I wanted to bring my GitHub Pages hobby projects onto this site witout a complicated workflow, Vercel rewrites to the rescue."
 date: 2026-05-09
 tags:
   - posts
@@ -10,16 +10,16 @@ topics:
   - vercel
   - static sites
   - GitHub Pages
-kens_status: draft
+kens_status: published
 ---
 
 {% markdown %}
 
-I've been building hobby projects for years. Each one gets a write-up here and a link to GitHub Pages, but the project itself lives at `khawkins98.github.io/project-name/`: someone else's domain. You can read about PDF-A-go-go or pinment on this site, but you can't actually reach either project from here. They're linked, not present.
+I've been building hobby projects for years. Normally I'll give the better ones a write-up here and a link to GitHub Pages, but the project itself lives at `khawkins98.github.io/project-name/`.
 
-I wanted to bring them on-domain without the obvious headaches: dozens of subdomains is more infrastructure than any of these deserve, and copying build output into the main repo defeats the point of keeping them separate.
+I wanted to bring them on-domain without the obvious headaches: dozens of subdomains is more infrastructure than any of these deserve, subdomains stillconfuse many people, and copying build output into the main repo defeats the point of keeping them separate.
 
-GitHub Pages already solved the mapping problem -- one repo, one directory path. Could I just have my own domain do the same: proxy `/repo-name/` to whatever GitHub Pages is already serving?
+Could I just have my site do it like GitHub Pages? ... proxy `/repo-name/` to whatever GitHub is already serving?
 
 > ## tl;dr
 >
@@ -35,14 +35,17 @@ The obvious path is a merge: monorepo, or move each project to Vercel as a separ
 
 ## How the proxy works
 
-This assumes the main site is already on Vercel and each project already serves from `https://khawkins98.github.io/repo-name/`.
+My site was already on Vercel and each project already served from a `https://khawkins98.github.io/repo-name/`.
 
-A Vercel `rewrite` proxies a path prefix to any external origin. Minimum viable `vercel.json`:
+Then I used Vercel `rewrite` proxies a path prefix to any external origin. Minimum viable `vercel.json`:
 
 ```json
 {
   "rewrites": [
-    { "source": "/PDF-A-go-go/:path*", "destination": "https://khawkins98.github.io/PDF-A-go-go/:path*" }
+    {
+      "source": "/PDF-A-go-go/:path*",
+      "destination": "https://khawkins98.github.io/PDF-A-go-go/:path*"
+    }
   ]
 }
 ```
@@ -53,7 +56,7 @@ This works for every path except the project root.
 
 ## The trailing-slash problem
 
-Go to `allaboutken.com/PDF-A-go-go/` and you get a 404, even with the rewrite in place. The reason is Vercel's processing order: filesystem matching (including a directory-index check for `build/PDF-A-go-go/index.html`) runs before rewrites. That file doesn't exist in the main site's build, so Vercel 404s before the rewrite ever fires.
+Going to `allaboutken.com/PDF-A-go-go/` still gave a 404, even with the rewrite in place. The reason is Vercel's processing order: filesystem matching (including a directory-index check for `build/PDF-A-go-go/index.html`) runs before rewrites. That file doesn't exist in the main site's build, so Vercel 404s before the rewrite ever fires.
 
 Two `redirects` entries fix it. Redirects run before filesystem matching:
 
@@ -64,14 +67,15 @@ Two `redirects` entries fix it. Redirects run before filesystem matching:
     { "source": "/PDF-A-go-go/", "destination": "/PDF-A-go-go/index.html", "permanent": false }
   ],
   "rewrites": [
-    { "source": "/PDF-A-go-go/:path*", "destination": "https://khawkins98.github.io/PDF-A-go-go/:path*" }
+    {
+        "source": "/PDF-A-go-go/:path*",
+        "destination": "https://khawkins98.github.io/PDF-A-go-go/:path*"
+    }
   ]
 }
 ```
 
-Visiting `/PDF-A-go-go/` now redirects (302) to `/PDF-A-go-go/index.html`. No directory-index ambiguity; the rewrite fires and proxies to GitHub Pages. The browser ends up at `/PDF-A-go-go/index.html`, where relative asset paths like `./app.js` resolve correctly to `/PDF-A-go-go/app.js`. Bare root-relative paths like `/styles.css` would serve from the main site root instead. Fix those in the hobby project before proxying.
-
-I couldn't find this behavior documented anywhere. If you hit 404s on the project root, that's the fix.
+Visiting `/PDF-A-go-go/` now redirects (302) to `/PDF-A-go-go/index.html`. No directory-index ambiguity; the rewrite fires and proxies to GitHub Pages. The browser ends up at `/PDF-A-go-go/index.html`, where relative asset paths like `./app.js` resolve correctly to `/PDF-A-go-go/app.js`.
 
 ## Not burning the old address
 
@@ -88,9 +92,9 @@ But visitors arriving at the old URL should reach the canonical one. A small scr
 
 The hostname check is essential. Without it, the redirect fires on the proxied page too: allaboutken.com proxies to github.io, github.io redirects back to allaboutken.com, repeat. The check breaks the loop.
 
-## One wrinkle: CORS for shared JS assets
+## Don't forget: CORS for shared JS assets
 
-[pinment](/posts/20260225-introducing-pinment/) is a bookmarklet tool. Its install snippet builds a script URL from `window.location.origin` at runtime, so it always points to whichever domain the user is visiting from. Through the Vercel proxy, that becomes `allaboutken.com/pinment/pinment-bookmarklet.js`, which the rewrite proxies correctly to GitHub Pages.
+[Pinment](/posts/20260225-introducing-pinment/) is a bookmarklet tool. Its install snippet builds a script URL from `window.location.origin` at runtime, so it always points to whichever domain the user is visiting from. Through the Vercel proxy, that becomes `allaboutken.com/pinment/pinment-bookmarklet.js`, which the rewrite proxies correctly to GitHub Pages.
 
 `<script src>` tags don't trigger CORS, but `fetch()` does. A `headers` block in `vercel.json` covers it:
 
@@ -129,7 +133,7 @@ Worth adding for any project that exposes public JS assets loaded programmatical
 
 ## Adding another project
 
-1. Confirm GitHub Pages is enabled and serving at `khawkins98.github.io/repo-name/`.
+1. Confirm GitHub Pages is enabled and serving at `USERNAME.github.io/repo-name/`.
 2. Check asset paths: `./`-relative or prefixed with the repo name. Bare `/styles.css` will break.
 3. Add two `redirects` entries and one `rewrite` to `vercel.json`.
 4. Add the hostname-check script and `<link rel="canonical">` to the project's `index.html`.
@@ -139,9 +143,6 @@ For SPAs with client-side routing: the project needs a `404.html` on GitHub Page
 
 The full configuration and checklist live in [`vercel.json`](https://github.com/khawkins98/allaboutken-11ty/blob/main/vercel.json) and [`docs/DEPLOYMENT.md`](https://github.com/khawkins98/allaboutken-11ty/blob/main/docs/DEPLOYMENT.md). Nothing about the project deploys has to change: GitHub Pages stays the origin, Vercel becomes the routing layer. See what it looks like in practice at the [garage](/garage/). If you've proxied projects this way — or found a cleaner approach — I'd be glad to hear about it. The projects just get to live at home.
 
-## Related posts
-
-- [Introducing pinment](/posts/20260225-introducing-pinment/)
-- [PDF-A-go-go: an embeddable PDF viewer](/posts/20250811-pdf-a-go-go/)
+I think this is a fairly clean way to bring my web projects back "home" without the server compexities.
 
 {% endmarkdown %}

--- a/src/site/posts/DRAFT-20260509-vercel-proxy-hobby-projects.njk
+++ b/src/site/posts/DRAFT-20260509-vercel-proxy-hobby-projects.njk
@@ -1,7 +1,7 @@
 ---
 title: "Building a garage for hobby projects on your personal site"
 layout: layouts/post.njk
-teaser: "Years of hobby projects on GitHub Pages, scattered across a subdomain I don't own. Vercel rewrites brought them home without touching a single deploy pipeline."
+teaser: "Years of GitHub Pages hobby projects scattered across a subdomain I don't own; Vercel rewrites brought them home without touching a deploy pipeline."
 date: 2026-05-09
 tags:
   - posts
@@ -15,9 +15,9 @@ kens_status: draft
 
 {% markdown %}
 
-I've been building hobby projects for years. Small tools, experiments, things that scratch an itch. Each one lives in its own repo, deploys to GitHub Pages via CI, and gets a write-up here -- and then sits at `khawkins98.github.io/project-name/`. Someone else's domain. Superficially connected to my work via blog posts and cross-links, but not really living with it.
+I've been building hobby projects for years: small tools, experiments, things that scratch an itch. Each one lives in its own repo, deploys to GitHub Pages via CI, and gets a write-up here -- and then sits at `khawkins98.github.io/project-name/`. Someone else's domain. The cross-links keep things loosely connected, but the projects aren't really living with my work.
 
-I wanted a garage. A place on my own domain where this stuff could live together: `allaboutken.com/PDF-A-go-go/`, `allaboutken.com/pinment/`, whatever comes next. Not a portfolio -- more like a workshop wall where the tools are visible and reachable from one address. And I didn't want to change how any of them deploy.
+I wanted a garage, a place on my own domain where this stuff could live together: `allaboutken.com/PDF-A-go-go/`, `allaboutken.com/pinment/`, whatever comes next. It's not a portfolio: more like a workshop wall where the tools are visible and reachable from one address. And I didn't want to change how any of them deploy.
 
 > ## tl;dr
 >
@@ -29,9 +29,9 @@ I wanted a garage. A place on my own domain where this stuff could live together
 
 ## What I didn't want to do
 
-The obvious path is a merge: monorepo, or move each project to Vercel as a separate deployment. Both mean real work per project -- consolidated CI, shared dependency trees, combined issue trackers. Hobby projects earn their independence precisely because they're free to be messy and self-contained. The right fix is a smarter routing layer in front, not a restructuring underneath.
+The obvious path is a merge: monorepo, or move each project to Vercel as a separate deployment. Both mean real work per project: consolidated CI, shared dependency trees, combined issue trackers. Hobby projects earn their independence precisely because they're free to be messy and self-contained. The right fix is a smarter routing layer in front, not a restructuring underneath.
 
-## The approach
+## How the proxy works
 
 This assumes the main site is already on Vercel and each project already serves from `https://khawkins98.github.io/repo-name/`.
 
@@ -67,7 +67,7 @@ Two `redirects` entries fix it. Redirects run before filesystem matching:
 }
 ```
 
-Visiting `/PDF-A-go-go/` now redirects (302) to `/PDF-A-go-go/index.html`. No directory-index ambiguity; the rewrite fires and proxies to GitHub Pages. The browser ends up at `/PDF-A-go-go/index.html`, where relative asset paths like `./app.js` resolve correctly to `/PDF-A-go-go/app.js`. Bare root-relative paths like `/styles.css` would serve from the main site root instead -- fix those in the hobby project before proxying.
+Visiting `/PDF-A-go-go/` now redirects (302) to `/PDF-A-go-go/index.html`. No directory-index ambiguity; the rewrite fires and proxies to GitHub Pages. The browser ends up at `/PDF-A-go-go/index.html`, where relative asset paths like `./app.js` resolve correctly to `/PDF-A-go-go/app.js`. Bare root-relative paths like `/styles.css` would serve from the main site root instead. Fix those in the hobby project before proxying.
 
 I couldn't find this behavior documented anywhere. If you hit 404s on the project root, that's the fix.
 
@@ -133,7 +133,7 @@ Worth adding for any project that exposes public JS assets loaded programmatical
 
 For SPAs with client-side routing: the project needs a `404.html` on GitHub Pages that loads `index.html`. The proxy can't route to paths the GH Pages deploy doesn't know about.
 
-The full configuration and checklist live in [`vercel.json`](https://github.com/khawkins98/allaboutken-11ty/blob/main/vercel.json) and [`docs/DEPLOYMENT.md`](https://github.com/khawkins98/allaboutken-11ty/blob/main/docs/DEPLOYMENT.md). Nothing about the project deploys has to change: GitHub Pages stays the origin, Vercel becomes the routing layer. The projects just get to live at home.
+The full configuration and checklist live in [`vercel.json`](https://github.com/khawkins98/allaboutken-11ty/blob/main/vercel.json) and [`docs/DEPLOYMENT.md`](https://github.com/khawkins98/allaboutken-11ty/blob/main/docs/DEPLOYMENT.md). Nothing about the project deploys has to change: GitHub Pages stays the origin, Vercel becomes the routing layer. See what it looks like in practice at the [garage](/garage/). If you've proxied projects this way — or found a cleaner approach — I'd be glad to hear about it. The projects just get to live at home.
 
 ## Related posts
 

--- a/src/site/posts/DRAFT-20260509-vercel-proxy-hobby-projects.njk
+++ b/src/site/posts/DRAFT-20260509-vercel-proxy-hobby-projects.njk
@@ -1,0 +1,143 @@
+---
+title: "Building a garage for hobby projects on your personal site"
+layout: layouts/post.njk
+teaser: "Years of hobby projects on GitHub Pages, scattered across a subdomain I don't own. Vercel rewrites brought them home without touching a single deploy pipeline."
+date: 2026-05-09
+tags:
+  - posts
+topics:
+  - web development
+  - vercel
+  - static sites
+  - GitHub Pages
+kens_status: draft
+---
+
+{% markdown %}
+
+I've been building hobby projects for years. Small tools, experiments, things that scratch an itch. Each one lives in its own repo, deploys to GitHub Pages via CI, and gets a write-up here -- and then sits at `khawkins98.github.io/project-name/`. Someone else's domain. Superficially connected to my work via blog posts and cross-links, but not really living with it.
+
+I wanted a garage. A place on my own domain where this stuff could live together: `allaboutken.com/PDF-A-go-go/`, `allaboutken.com/pinment/`, whatever comes next. Not a portfolio -- more like a workshop wall where the tools are visible and reachable from one address. And I didn't want to change how any of them deploy.
+
+> ## tl;dr
+>
+> - Vercel `rewrites` proxy `/project-name/:path*` to the GitHub Pages origin -- no deploy changes required
+> - A naive rewrite 404s on the project root; two `redirects` entries (bare path and trailing slash → `/project-name/index.html`) fix it
+> - Each project keeps its GitHub Pages URL; a hostname-check script redirects those visitors to the canonical URL
+> - CORS headers on proxied paths cover shared JS assets loaded via `fetch()`
+> - A `/garage/` index page on the main site ties all the projects together
+
+## What I didn't want to do
+
+The obvious path is a merge: monorepo, or move each project to Vercel as a separate deployment. Both mean real work per project -- consolidated CI, shared dependency trees, combined issue trackers. Hobby projects earn their independence precisely because they're free to be messy and self-contained. The right fix is a smarter routing layer in front, not a restructuring underneath.
+
+## The approach
+
+This assumes the main site is already on Vercel and each project already serves from `https://khawkins98.github.io/repo-name/`.
+
+A Vercel `rewrite` proxies a path prefix to any external origin. Minimum viable `vercel.json`:
+
+```json
+{
+  "rewrites": [
+    { "source": "/PDF-A-go-go/:path*", "destination": "https://khawkins98.github.io/PDF-A-go-go/:path*" }
+  ]
+}
+```
+
+Requests to `allaboutken.com/PDF-A-go-go/anything` forward to `khawkins98.github.io/PDF-A-go-go/anything`. The GitHub Pages deploy keeps working at its original URL unchanged.
+
+This works for every path except the project root.
+
+## The trailing-slash problem
+
+Go to `allaboutken.com/PDF-A-go-go/` and you get a 404, even with the rewrite in place. The reason is Vercel's processing order: filesystem matching (including a directory-index check for `build/PDF-A-go-go/index.html`) runs before rewrites. That file doesn't exist in the main site's build, so Vercel 404s before the rewrite ever fires.
+
+Two `redirects` entries fix it. Redirects run before filesystem matching:
+
+```json
+{
+  "redirects": [
+    { "source": "/PDF-A-go-go",  "destination": "/PDF-A-go-go/index.html", "permanent": false },
+    { "source": "/PDF-A-go-go/", "destination": "/PDF-A-go-go/index.html", "permanent": false }
+  ],
+  "rewrites": [
+    { "source": "/PDF-A-go-go/:path*", "destination": "https://khawkins98.github.io/PDF-A-go-go/:path*" }
+  ]
+}
+```
+
+Visiting `/PDF-A-go-go/` now redirects (302) to `/PDF-A-go-go/index.html`. No directory-index ambiguity; the rewrite fires and proxies to GitHub Pages. The browser ends up at `/PDF-A-go-go/index.html`, where relative asset paths like `./app.js` resolve correctly to `/PDF-A-go-go/app.js`. Bare root-relative paths like `/styles.css` would serve from the main site root instead -- fix those in the hobby project before proxying.
+
+I couldn't find this behavior documented anywhere. If you hit 404s on the project root, that's the fix.
+
+## Not burning the old address
+
+GitHub Pages keeps serving at `khawkins98.github.io/project-name/`. The Vercel setup is additive: the personal domain gains a route, the original URL stays live. Rolling back is two deleted lines in `vercel.json`.
+
+But visitors arriving at the old URL should reach the canonical one. A small script at the top of each project's `<head>`:
+
+```html
+<script>if(window.location.hostname==='khawkins98.github.io'){window.location.replace('https://www.allaboutken.com/PDF-A-go-go/')}</script>
+<link rel="canonical" href="https://www.allaboutken.com/PDF-A-go-go/">
+```
+
+The hostname check is essential. Without it, the redirect fires on the proxied page too: allaboutken.com proxies to github.io, github.io redirects back to allaboutken.com, repeat. The check breaks the loop.
+
+## One wrinkle: CORS for shared JS assets
+
+[pinment](/posts/20260225-introducing-pinment/) is a bookmarklet tool. Its install snippet builds a script URL from `window.location.origin` at runtime, so it always points to whichever domain the user is visiting from. Through the Vercel proxy, that becomes `allaboutken.com/pinment/pinment-bookmarklet.js`, which the rewrite proxies correctly to GitHub Pages.
+
+`<script src>` tags don't trigger CORS, but `fetch()` does. A `headers` block in `vercel.json` covers it:
+
+```json
+{
+  "headers": [
+    { "source": "/pinment/:path*", "headers": [{ "key": "Access-Control-Allow-Origin", "value": "*" }] }
+  ]
+}
+```
+
+Worth adding for any project that exposes public JS assets loaded programmatically from other pages.
+
+## The full configuration
+
+```json
+{
+  "buildCommand": "yarn build",
+  "outputDirectory": "build",
+  "headers": [
+    { "source": "/PDF-A-go-go/:path*", "headers": [{ "key": "Access-Control-Allow-Origin", "value": "*" }] },
+    { "source": "/pinment/:path*", "headers": [{ "key": "Access-Control-Allow-Origin", "value": "*" }] }
+  ],
+  "redirects": [
+    { "source": "/PDF-A-go-go",  "destination": "/PDF-A-go-go/index.html", "permanent": false },
+    { "source": "/PDF-A-go-go/", "destination": "/PDF-A-go-go/index.html", "permanent": false },
+    { "source": "/pinment",  "destination": "/pinment/index.html", "permanent": false },
+    { "source": "/pinment/", "destination": "/pinment/index.html", "permanent": false }
+  ],
+  "rewrites": [
+    { "source": "/PDF-A-go-go/:path*", "destination": "https://khawkins98.github.io/PDF-A-go-go/:path*" },
+    { "source": "/pinment/:path*", "destination": "https://khawkins98.github.io/pinment/:path*" }
+  ]
+}
+```
+
+## Adding another project
+
+1. Confirm GitHub Pages is enabled and serving at `khawkins98.github.io/repo-name/`.
+2. Check asset paths: `./`-relative or prefixed with the repo name. Bare `/styles.css` will break.
+3. Add two `redirects` entries and one `rewrite` to `vercel.json`.
+4. Add the hostname-check script and `<link rel="canonical">` to the project's `index.html`.
+5. Add the project to the [garage page](/garage/).
+
+For SPAs with client-side routing: the project needs a `404.html` on GitHub Pages that loads `index.html`. The proxy can't route to paths the GH Pages deploy doesn't know about.
+
+The full configuration and checklist live in [`vercel.json`](https://github.com/khawkins98/allaboutken-11ty/blob/main/vercel.json) and [`docs/DEPLOYMENT.md`](https://github.com/khawkins98/allaboutken-11ty/blob/main/docs/DEPLOYMENT.md). Nothing about the project deploys has to change: GitHub Pages stays the origin, Vercel becomes the routing layer. The projects just get to live at home.
+
+## Related posts
+
+- [Introducing pinment](/posts/20260225-introducing-pinment/)
+- [PDF-A-go-go: an embeddable PDF viewer](/posts/20250811-pdf-a-go-go/)
+
+{% endmarkdown %}

--- a/src/site/posts/DRAFT-20260509-vercel-proxy-hobby-projects.njk
+++ b/src/site/posts/DRAFT-20260509-vercel-proxy-hobby-projects.njk
@@ -15,9 +15,11 @@ kens_status: draft
 
 {% markdown %}
 
-I've been building hobby projects for years: small tools, experiments, things that scratch an itch. Each one lives in its own repo, deploys to GitHub Pages via CI, and gets a write-up here -- and then sits at `khawkins98.github.io/project-name/`. Someone else's domain. The cross-links keep things loosely connected, but the projects aren't really living with my work.
+I've been building hobby projects for years. Each one gets a write-up here and a link to GitHub Pages, but the project itself lives at `khawkins98.github.io/project-name/`: someone else's domain. You can read about PDF-A-go-go or pinment on this site, but you can't actually reach either project from here. They're linked, not present.
 
-I wanted a garage, a place on my own domain where this stuff could live together: `allaboutken.com/PDF-A-go-go/`, `allaboutken.com/pinment/`, whatever comes next. It's not a portfolio: more like a workshop wall where the tools are visible and reachable from one address. And I didn't want to change how any of them deploy.
+I wanted to bring them on-domain without the obvious headaches: dozens of subdomains is more infrastructure than any of these deserve, and copying build output into the main repo defeats the point of keeping them separate.
+
+GitHub Pages already solved the mapping problem -- one repo, one directory path. Could I just have my own domain do the same: proxy `/repo-name/` to whatever GitHub Pages is already serving?
 
 > ## tl;dr
 >
@@ -74,6 +76,8 @@ I couldn't find this behavior documented anywhere. If you hit 404s on the projec
 ## Not burning the old address
 
 GitHub Pages keeps serving at `khawkins98.github.io/project-name/`. The Vercel setup is additive: the personal domain gains a route, the original URL stays live. Rolling back is two deleted lines in `vercel.json`.
+
+For now I've only moved two projects across -- PDF-A-go-go and pinment -- while I confirm that existing embed links aren't affected. The redirect from `khawkins98.github.io` to the proxied URL could in theory break things for anyone who has embedded the old URL directly. Once it's clear nothing is breaking, adding the rest is a few lines in `vercel.json`.
 
 But visitors arriving at the old URL should reach the canonical one. A small script at the top of each project's `<head>`:
 


### PR DESCRIPTION
## Summary
- add and polish a new /garage/ index page with intro narrative, component-aligned project cards, and a How this works section
- draft a companion post documenting path-based proxying of GitHub Pages projects through Vercel
- refine post framing around discoverability: projects were linked but not present on-domain
- document cautious rollout: currently moving two projects first while validating existing embed links
- add explicit GitHub repositories link for readers who want the full project list

## Additional repo updates on this branch
- simplify commit convention in CONTRIBUTING to thematic prefixes (content, feature, fix, ci, chore)
- enforce prefix format via local .githooks/commit-msg and PR title check workflow

## Notes
- this keeps project repos and GH Pages deploys independent while Vercel handles routing at the main-domain layer
