### PR TITLE
chore: tighten commit-msg hook with length and period checks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,24 +1,44 @@
 #!/usr/bin/env bash
 # Enforces the commit message convention: <prefix>: <description>
 # See CONTRIBUTING.md for the full list of prefixes.
+set -euo pipefail
 
-commit_msg=$(cat "$1")
+msg_file="$1"
 
-# Skip merge, revert, and fixup commits — they're machine-generated
-if echo "$commit_msg" | grep -qE "^(Merge |Revert |fixup! |squash! )"; then
-  exit 0
-fi
+# First non-comment, non-empty line is the subject.
+subject="$(grep -v '^#' "$msg_file" | sed '/^[[:space:]]*$/d' | head -n 1 || true)"
 
-pattern="^(content|feature|fix|ci|chore): .+"
+# Skip merge, revert, and fixup commits — they are machine-generated.
+case "$subject" in
+  "Merge "*|"Revert "*|"fixup! "*|"squash! "*) exit 0 ;;
+esac
 
-if ! echo "$commit_msg" | grep -qE "$pattern"; then
+allowed_prefixes="content | feature | fix | ci | chore"
+prefix_pattern='^(content|feature|fix|ci|chore): .+'
+
+fail() {
   echo ""
-  echo "  ❌  Commit message format error"
+  echo "  ❌  Commit message format error: $1"
   echo ""
   echo "  Expected:  <prefix>: <description>"
-  echo "  Prefixes:  content | feature | fix | ci | chore"
+  echo "  Prefixes:  ${allowed_prefixes}"
+  echo "  Rules:     subject ≤ 72 chars, no trailing period"
   echo ""
-  echo "  Got:  $commit_msg"
+  echo "  Got:  ${subject}"
   echo ""
   exit 1
+}
+
+if ! [[ "$subject" =~ $prefix_pattern ]]; then
+  fail "missing or unknown prefix"
 fi
+
+if (( ${#subject} > 72 )); then
+  fail "subject is ${#subject} chars (max 72)"
+fi
+
+case "$subject" in
+  *.) fail "subject ends with a period" ;;
+esac
+
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,8 @@ Examples:
 
 ### General rules
 
-- First line ≤ 72 characters when practical
+- First line ≤ 72 characters (enforced by the hook)
+- No trailing period on the subject (enforced by the hook)
 - Body optional; when present, focus on the *why* (the diff already shows the *what*)
 - One logical change per commit
 - Never use `--no-verify` or `--no-gpg-sign` to bypass hooks


### PR DESCRIPTION
## Summary
- Hook now parses the subject line (first non-comment, non-empty line) instead of the whole message, so trailers and bodies don't interfere
- Adds enforcement for subject ≤ 72 chars and no trailing period, on top of the existing prefix check
- Switches to `set -euo pipefail` and a `fail()` helper that reports the specific rule violated

## Test plan
- [ ] Commit with valid prefix and short subject — passes
- [ ] Commit with bad prefix — fails with "missing or unknown prefix"
- [ ] Commit with > 72 char subject — fails with char count
- [ ] Commit with trailing period — fails with period message
- [ ] Merge/revert/fixup/squash commits — still skip