### PR TITLE
chore: add missing documentation for search architecture, CSS architecture, and eleventy.js

### DIFF
--- a/docs/CSS_ARCHITECTURE.md
+++ b/docs/CSS_ARCHITECTURE.md
@@ -1,0 +1,92 @@
+# CSS architecture
+
+---
+
+## Sass entry point
+
+All styles are compiled from a single entry point:
+
+```
+src/components/vf-componenet-rollup/index.scss
+```
+
+> **Note:** the directory name `vf-componenet-rollup` (with the transposed letters in "component") is a legacy typo. **Do not rename it** — renaming would break the build and any tooling that references the path by name.
+
+The entry point uses `@use` (not `@import`) to pull in partials:
+
+| Partial | Purpose |
+|---|---|
+| `normalize` | CSS normalisation reset |
+| `kh-content` | Main content and layout styles |
+| `settings` | Breakpoint and colour variables |
+| `semantic-search` | Search UI styles |
+| `../kh-ambience/kh-ambience` | Ambient / background styles |
+
+---
+
+## CSS-free viewing mode
+
+The entire custom stylesheet is scoped under a single root selector:
+
+```scss
+body:has(#kh-css-toggle:checked) {
+  /* all custom styles go here */
+}
+```
+
+A visually-hidden checkbox (`#kh-css-toggle`) in the page controls whether styles are applied. When unchecked, the page renders with only browser defaults, enabling a "CSS naked" / accessible view.
+
+**This means every new style rule must be written inside the `body:has(#kh-css-toggle:checked)` block.** Rules placed outside this scope will apply unconditionally and break the CSS-free mode.
+
+The only exceptions are rules that must apply regardless of the toggle, such as `html { scroll-behavior: smooth }` and `@media (prefers-reduced-motion)` which appear before the root selector in `index.scss`.
+
+---
+
+## Breakpoints
+
+Breakpoint variables are defined in `_settings.scss`:
+
+| Variable | Value |
+|---|---|
+| `$kh-breakpoint--sm` | `600px` |
+| `$kh-breakpoint--md` | `846px` |
+| `$kh-breakpoint--lg` | `1024px` |
+| `$kh-breakpoint--xl` | `1300px` |
+| `$kh-breakpoint--sm-down` | `599px` (one below sm) |
+| `$kh-breakpoint--md-down` | `845px` (one below md) |
+| `$kh-breakpoint--lg-down` | `1023px` (one below lg) |
+
+Use `@media (min-width: $kh-breakpoint--md)` for mobile-first breakpoints.
+
+---
+
+## Nesting and selector limits
+
+The Stylelint configuration enforces:
+
+- **Max nesting depth: 1** for regular rules. Blockless at-rules (`@media`, `@supports`) are exempt and do not count toward the depth.
+- **Max compound selectors: 3** per rule.
+- **Number precision: 4** decimal places.
+
+Keep selectors flat. Nest only when there is a direct parent–child relationship that cannot be expressed otherwise.
+
+---
+
+## Adding new styles
+
+1. Open (or create) the relevant partial under `src/components/vf-componenet-rollup/`.
+2. Place all rules inside the `body:has(#kh-css-toggle:checked)` mixin or block. If you are adding to a partial that is `@include`d by `index.scss`, your rules are already inside that scope as long as you follow the existing file structure.
+3. Use `@use` to import any settings variables you need — do not use `@import`.
+4. Run `yarn lint:css` before committing to catch nesting depth, compound-selector, and duplicate-selector violations.
+5. Run `yarn sass` (or `yarn dev`) to verify the compiled CSS is valid.
+
+---
+
+## Linting
+
+```bash
+yarn lint:css         # check all SCSS/CSS files
+yarn lint:css:fix     # auto-fix fixable violations
+```
+
+The linter is configured in `.stylelintrc.json` using `stylelint-config-recommended-scss` and `@stylistic/stylelint-plugin`.

--- a/docs/SEARCH.md
+++ b/docs/SEARCH.md
@@ -1,0 +1,94 @@
+# Search architecture
+
+The site provides two complementary search modes, selectable by the user:
+
+- **Keyword search** — fast, offline-capable, uses a Pagefind index built at compile time.
+- **Semantic / "Ask" search** — natural-language queries using vector embeddings generated at build time and compared in the browser.
+
+---
+
+## Keyword search (Pagefind)
+
+### How it works
+
+After every Eleventy build, a `pagefind.after` hook runs:
+
+```js
+const cmd = 'pagefind --site build --exclude-selectors "pre, code"';
+```
+
+Pagefind crawls the `build/` directory and writes a binary index under `build/pagefind/`. The browser-side Pagefind JS (loaded from that same path) does all querying locally — no server needed.
+
+Code blocks (`pre`, `code`) are excluded from the index so that searches for common words don't surface noise from examples.
+
+### Excluding content from the index
+
+Add `data-pagefind-ignore` to any element whose text should not be indexed. The social-card layout and page header already use this attribute.
+
+### Client-side integration
+
+The search page (`src/site/search.njk`) loads the Pagefind UI bundle from `/pagefind/pagefind-ui.js`. No configuration beyond pointing it at the right `bundlePath` is required.
+
+### Dev vs production
+
+In development (`ELEVENTY_ENV=development`), Pagefind runs asynchronously after each Eleventy rebuild so it doesn't block the dev server. In production it runs synchronously (via `execSync`) so the build fails loudly if the index cannot be created.
+
+---
+
+## Semantic / vector search
+
+### Overview
+
+Semantic search lets visitors ask natural-language questions and find pages by meaning rather than exact keywords. It works by:
+
+1. **Build time** — generating a 384-dimensional embedding vector for every page and saving them to `build/semantic-search/vectors.json`.
+2. **Query time** — the browser embeds the user's query with the same model and computes cosine similarity (dot product of unit vectors) against all stored vectors, then returns the top matches.
+
+### Model
+
+Both sides must use the same model:
+
+| Location | Constant | Value |
+|---|---|---|
+| `scripts/generate-embeddings.mjs` | `MODEL_NAME` | `Xenova/all-MiniLM-L6-v2` |
+| `src/site/semantic-search.js` | `MODEL_ID` | `Xenova/all-MiniLM-L6-v2` |
+
+**If you change the model you must update both files and re-run `yarn build`.** Mismatched models produce silently wrong results — query vectors and page vectors become incomparable.
+
+### Build-time embedding generation (`scripts/generate-embeddings.mjs`)
+
+- Reads all HTML files in `build/`.
+- Skips non-content paths (social cards, sitemap, pagefind index, etc.) via `SKIP_PATTERNS`.
+- Extracts text from elements that carry `data-pagefind-body` to match what Pagefind indexes.
+- Runs the MiniLM pipeline (`feature-extraction` task) for each page.
+- Normalises vectors so that dot product equals cosine similarity.
+- Writes `build/semantic-search/vectors.json`.
+
+Run order: `yarn eleventy` (which also runs Pagefind) **then** `yarn embeddings`. `yarn build` does both automatically.
+
+The `@huggingface/transformers` devDependency is ~476 MB because the ONNX runtime ships native binaries for every platform. There is no lighter alternative for build-time inference.
+
+### Browser-side query (`src/site/semantic-search.js`)
+
+- Loaded as an ES module (`<script type="module">`).
+- Lazy-loads Transformers.js from jsDelivr and the model from HuggingFace on first query.
+- Transformers.js caches the model (~23 MB) in the browser's Cache API keyed by model ID, so the download only happens once per browser.
+- Scores pages with `dotSimilarity()` (pre-normalised vectors → dot product = cosine similarity).
+- Surfaces the top results above a relevance threshold.
+
+### Updating the model
+
+1. Browse [Transformers.js-compatible models](https://huggingface.co/models?library=transformers.js&sort=trending) — look for ONNX exports with `sentence-transformers`.
+2. Update `MODEL_NAME` in `scripts/generate-embeddings.mjs`.
+3. Update `MODEL_ID` in `src/site/semantic-search.js`.
+4. Run `yarn build` to regenerate embeddings with the new model.
+5. Test both search modes to confirm results are coherent.
+
+### Running embeddings locally
+
+```bash
+yarn clean && yarn sass && yarn eleventy   # fast iteration (no embeddings)
+yarn build                                  # full build including embeddings (~5+ min)
+```
+
+Embeddings do not run during `yarn dev`. Run `yarn build` once to produce `build/semantic-search/vectors.json`, then continue with `yarn dev`.

--- a/eleventy.js
+++ b/eleventy.js
@@ -1,3 +1,22 @@
+/**
+ * Eleventy configuration — allaboutken-11ty
+ *
+ * Sections (in order):
+ *   1. Plugins        — eleventyImageTransformPlugin (responsive image transforms)
+ *   2. Server options — dev-server live-reload and HTTPS stubs
+ *   3. Transforms     — fixImageSrcToAbsolute (rewrite build-time img paths)
+ *   4. Filters        — dateDisplay, limitItems, ensureTrailingSlash, rssDate,
+ *                       rssLastUpdatedDate, emdash, htmlToAbsoluteUrls,
+ *                       sanitizeFeedHtml, wordCount, formatNumber
+ *   5. Markdown       — markdown-it with heading anchors + emdash plugin;
+ *                       `markdown` paired shortcode
+ *   6. Shortcodes     — codeAndDemo (paired), ogImageUrl
+ *   7. Passthrough    — JS files, favicon assets, images, fonts, legacy HTML
+ *   8. Pagefind hook  — post-build keyword-search index (async in dev, sync in prod)
+ *   9. Collections    — impactStories, blogPosts, allContent
+ *  10. Return config  — dir, templateFormats, template engine overrides
+ */
+
 const { DateTime } = require('luxon');
 const Path         = require('path');
 const { execSync, exec } = require('child_process');

--- a/scripts/process-images.js
+++ b/scripts/process-images.js
@@ -1,0 +1,17 @@
+/**
+ * process-images.js — batch image pre-processing helper (not yet implemented)
+ *
+ * Intended as a CLI script to be run locally before committing new images.
+ * Future responsibilities:
+ *   - Accept a source image path (or glob) as a CLI argument
+ *   - Strip EXIF metadata (privacy)
+ *   - Resize / optimise to a sensible maximum dimension before committing
+ *   - Output to src/site/images/blog/ ready for Eleventy's image transform
+ *
+ * The Eleventy build already generates responsive AVIF/WebP/JPEG variants at
+ * build time via eleventyImageTransformPlugin; this script handles the
+ * upstream source images before they enter version control.
+ *
+ * Usage (planned):
+ *   node scripts/process-images.js <source-image> [<source-image> ...]
+ */


### PR DESCRIPTION
Backfills three areas of missing project documentation: (1) docs/SEARCH.md for the dual-search system (Pagefind + MiniLM-L6-v2 semantic search), (2) docs/CSS_ARCHITECTURE.md for the CSS-free toggle pattern and Sass conventions, (3) eleventy.js module-level header comment, and (4) scripts/process-images.js stub comment. Build verified: yarn eleventy ran successfully (246 files, 0 errors).


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:/Users/khawkins/Documents/git/allaboutken-11ty
task-type: docs-backfill
task-title: Documentation Backfiller
provider: copilot
score: 0.8
cost-tier: Low (10-50k)
branch: main
iterations: 2
duration: 53m1s
run-started: 2026-05-30T02:00:05+02:00
nightshift:metadata -->
