### PR TITLE
Draft: What people actually automate with coding agents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,7 @@ Track readiness via the `kens_status` frontmatter field:
 
 ## Before pushing
 
+- Use [`docs/SCRIPTS.md`](docs/SCRIPTS.md) as the source of truth for command behavior and expected outputs.
 - `yarn build` runs clean
 - `yarn lint:css` runs clean (for SCSS changes)
 - Visually confirm new or edited pages render locally via `yarn dev`
@@ -84,3 +85,4 @@ Always merge through a PR, even for solo work. Don't push directly to `main`. Re
 - [`docs/PUBLISHING_WORKFLOW.md`](docs/PUBLISHING_WORKFLOW.md): editorial review stages and roles
 - [`src/site/style-guide/editorial.njk`](src/site/style-guide/editorial.njk): voice, tone, structure
 - [`docs/IMAGE_GENERATION.md`](docs/IMAGE_GENERATION.md): hero image pipeline
+- [`docs/SCRIPTS.md`](docs/SCRIPTS.md): local commands and script behavior

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ eleventy.js       All config: filters, shortcodes, collections, image transform
 ```
 
 For the full stack breakdown and design principles, see the [colophon](https://www.allaboutken.com/colophon/).
+For contribution workflow and commit/PR conventions, see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+For the full documentation map, see [`docs/README.md`](docs/README.md).
+For command behavior and script lifecycle details, see [`docs/SCRIPTS.md`](docs/SCRIPTS.md).
 
 ## Social cards
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -59,6 +59,8 @@ Current DNS records for the main site:
 - **Deploy:** manually via `cd worker && npx wrangler deploy` (auto-deploy CI is currently broken — see `.github/workflows/deploy-feedback-worker.yml` for details)
 - Completely independent of the main site serving. Not affected by Vercel or DNS changes to the apex domain.
 
+Operational details for routes, local development, and wrangler usage are documented in [`worker/README.md`](../worker/README.md).
+
 ### GitHub Pages — main site (warm spare) and hobby project origins
 
 - **URL:** `khawkins98.github.io`
@@ -94,9 +96,9 @@ The redirect-to-index-html approach is necessary because Vercel's directory-inde
 
 2. **Check the project's asset paths.** Assets must use either relative `./` paths or paths prefixed with the repo name (e.g. `/my-project/foo.css`). Bare root-relative paths like `/foo.css` will break — Vercel serves them from the main site root. `./`-style relative paths work fine: because the browser URL ends with `/project-name/index.html`, `./` resolves to `/project-name/` as expected.
 
-2. **Check if it's a SPA.** Single-page apps that use client-side routing need a `404.html` that loads `index.html` on GitHub Pages, so that deep links work through the proxy. If the project has a `404.html` already that redirects to `index.html`, you're good.
+3. **Check if it's a SPA.** Single-page apps that use client-side routing need a `404.html` that loads `index.html` on GitHub Pages, so that deep links work through the proxy. If the project has a `404.html` already that redirects to `index.html`, you're good.
 
-3. **Add redirects and a rewrite to `vercel.json`:**
+4. **Add redirects and a rewrite to `vercel.json`:**
 
    ```json
    "redirects": [
@@ -110,11 +112,11 @@ The redirect-to-index-html approach is necessary because Vercel's directory-inde
 
    The two redirects are required because Vercel's directory-index check intercepts trailing-slash requests before any rewrite rule can fire. Redirects run before that check, so redirecting to the explicit `index.html` file lets the rewrite pick it up normally.
 
-4. **Add a row to the Rewrites table** in this file.
+5. **Add a row to the Rewrites table** in this file.
 
-5. **Commit and push.** Vercel will deploy automatically. Smoke-test `allaboutken.com/my-project/` once the deployment completes.
+6. **Commit and push.** Vercel will deploy automatically. Smoke-test `allaboutken.com/my-project/` once the deployment completes.
 
-6. **Optionally update the project's README** to note the canonical URL is now `allaboutken.com/my-project/`.
+7. **Optionally update the project's README** to note the canonical URL is now `allaboutken.com/my-project/`.
 
 ---
 
@@ -149,3 +151,9 @@ If Vercel needs to be removed:
 | Manual `workflow_dispatch` | Can trigger either workflow manually from the Actions tab |
 
 The GitHub Pages deploy in CI is currently a warm spare. Consider removing the `deploy` job from `.github/workflows/build-and-deploy.yml` once confidence in Vercel is established.
+
+## Operational runbooks
+
+- Main site + routing architecture: this file (`docs/DEPLOYMENT.md`)
+- Feedback worker implementation/runbook: [`worker/README.md`](../worker/README.md)
+- Local script and lifecycle behavior: [`docs/SCRIPTS.md`](SCRIPTS.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+# Documentation index
+
+Use this page as the entry point for repository documentation. It maps each doc to its intent, audience, and the moment you should reach for it.
+
+| Document | Purpose | Audience / owner | Use when |
+| --- | --- | --- | --- |
+| [`../README.md`](../README.md) | Project overview, stack, and quick start | Anyone entering the repo | You are orienting or setting up local dev |
+| [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Branch, commit, and PR conventions | Contributors and assistants | You are preparing commits, PR titles, and merge flow |
+| [`SCRIPTS.md`](SCRIPTS.md) | Source of truth for `package.json` scripts and lifecycle behavior | Contributors running local/CI commands | You need the right command and expected output |
+| [`DEPLOYMENT.md`](DEPLOYMENT.md) | Runtime architecture and platform ownership (Vercel, DNS, Pages, Worker) | Maintainer/operators | You are changing deploy config, DNS, or rewrites |
+| [`SEARCH.md`](SEARCH.md) | Keyword and semantic search architecture | Contributors touching search/indexing | You are changing Pagefind, embeddings, or search UI |
+| [`CSS_ARCHITECTURE.md`](CSS_ARCHITECTURE.md) | Sass structure and CSS toggle constraints | Contributors editing styles | You are adding or refactoring SCSS |
+| [`IMAGE_GENERATION.md`](IMAGE_GENERATION.md) | Hero image workflow and attribution rules | Content authors/editors | You are creating or updating post hero art |
+| [`PUBLISHING_WORKFLOW.md`](PUBLISHING_WORKFLOW.md) | Editorial stages, handoffs, and quality gates | Editorial roles and maintainers | You are moving a draft toward publication |
+| [`STYLE_REVIEW_PROCESS.md`](STYLE_REVIEW_PROCESS.md) | Editorial style review process | Editorial reviewers | You are running a focused style pass |
+| [`ROLE_TECHNICAL_REVIEWER.md`](ROLE_TECHNICAL_REVIEWER.md) | Technical reviewer role brief | Technical reviewers | You are doing technical correctness review |
+| [`ROLE_EDITORIAL_STYLE_EDITOR.md`](ROLE_EDITORIAL_STYLE_EDITOR.md) | Editorial style editor role brief | Style reviewers | You are editing for tone, structure, and readability |
+| [`ROLE_SEO_DISCOVERABILITY_EDITOR.md`](ROLE_SEO_DISCOVERABILITY_EDITOR.md) | SEO/discoverability role brief | SEO reviewers | You are improving metadata, findability, and internal links |
+| [`ROLE_TEMPLATE.md`](ROLE_TEMPLATE.md) | Template for defining new reviewer roles | Maintainers adding roles | You are introducing a new role profile |
+| [`../worker/README.md`](../worker/README.md) | Feedback worker routes, local dev, and deploy commands | Maintainer/operators | You are operating or debugging `feedback.allaboutken.com` |
+| [`../src/site/style-guide/editorial.njk`](../src/site/style-guide/editorial.njk) | Canonical voice/tone/style guidance | Authors and editors | You need writing standards while drafting or editing |
+
+## Suggested read paths
+
+- **New contributor:** `../README.md` -> `../CONTRIBUTING.md` -> `SCRIPTS.md`
+- **Content workflow:** `PUBLISHING_WORKFLOW.md` -> `../src/site/style-guide/editorial.njk` -> `IMAGE_GENERATION.md`
+- **Operations/deploy:** `DEPLOYMENT.md` -> `../worker/README.md`

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -1,0 +1,108 @@
+# Scripts reference
+
+Source of truth for local commands and script behavior in this repository.
+
+## At a glance
+
+| Command | Purpose | Typical use |
+| --- | --- | --- |
+| `yarn dev` | Run local development server | Day-to-day authoring and preview |
+| `yarn build` | Run full production build | Pre-push validation and CI parity |
+| `yarn embeddings` | Regenerate semantic-search vectors | After content/model changes that affect embeddings |
+| `yarn lint:css` | Lint SCSS/CSS files | Before committing style changes |
+
+## Script details
+
+### `yarn clean`
+
+- Runs `rm -rf build`.
+- Deletes generated output so the next build starts from a clean state.
+
+### `yarn sass`
+
+- Compiles `src/components/vf-componenet-rollup/index.scss` to `build/css/styles.css`.
+- Uses `--no-source-map`.
+- Run directly when you only need stylesheet compilation without a full site build.
+
+### `yarn eleventy`
+
+- Runs `ELEVENTY_ENV=production eleventy --config=eleventy.js`.
+- Produces static site output in `build/`.
+- Uses production mode behavior (different from `yarn dev`).
+
+### `yarn lint:css`
+
+- Runs stylelint on all `src/**/*.scss` and `src/**/*.css`.
+- Non-mutating check for CSS/SCSS quality.
+
+### `yarn lint:css:fix`
+
+- Same scope as `yarn lint:css`, but with `--fix` for auto-fixable issues.
+
+### `yarn embeddings`
+
+- Runs `node scripts/generate-embeddings.mjs`.
+- Reads generated HTML in `build/`, extracts searchable content, and writes `build/semantic-search/vectors.json`.
+- Intended to run after Eleventy has produced the site output.
+
+### `yarn build`
+
+- Runs: `yarn clean && yarn sass && yarn eleventy && yarn embeddings`.
+- This is the production build path used for full validation.
+- Expected outputs include:
+  - compiled CSS in `build/css/`
+  - site HTML/assets in `build/`
+  - semantic search vectors in `build/semantic-search/vectors.json`
+
+### `yarn dev`
+
+- Runs Sass in watch mode and Eleventy with `--serve` concurrently.
+- Uses `ELEVENTY_ENV=development`.
+- Optimized for local iteration.
+- Does **not** run `yarn embeddings` as part of the dev command.
+
+### `yarn start`
+
+- Alias for `yarn dev`.
+
+### `yarn test`
+
+- Placeholder script; currently prints an informational message and exits successfully.
+- There is no automated test suite wired via this command today.
+
+### `yarn prepare`
+
+- Sets Git hooks path: `git config core.hooksPath .githooks`.
+- Normally runs as part of dependency installation lifecycle.
+- Enables local commit-message enforcement via `.githooks/commit-msg`.
+
+## Lifecycle and automation notes
+
+### Install lifecycle (`prepare`)
+
+- `yarn install` runs `yarn prepare` automatically.
+- This repository uses that hook to point Git at `.githooks/`, so local commits are validated before they are created.
+
+### Commit message hook (`.githooks/commit-msg`)
+
+- Enforces `<prefix>: <description>` on the commit subject.
+- Allowed prefixes: `content`, `feature`, `fix`, `ci`, `chore`.
+- Enforces subject length <= 72 characters and disallows a trailing period.
+- Skips merge/revert/fixup/squash commit subjects.
+- Same convention is checked in CI for pull request titles by `.github/workflows/pr-title-check.yml`.
+
+### `yarn update-components`
+
+- Runs `yarn upgrade-interactive --latest` for dependency update workflow.
+
+## Scripts directory status
+
+### `scripts/generate-embeddings.mjs`
+
+- Active build script used by `yarn embeddings` and `yarn build`.
+
+### `scripts/process-images.js`
+
+- Planned helper script only; currently a documented placeholder.
+- It is **not** invoked by `yarn dev`, `yarn build`, or any npm/yarn script in `package.json`.
+- Eleventy image transforms are still handled at build time via the existing Eleventy image pipeline.

--- a/src/site/posts/20260624-what-you-automated-coding-agents.njk
+++ b/src/site/posts/20260624-what-you-automated-coding-agents.njk
@@ -1,0 +1,98 @@
+---
+title: "What people actually automate with coding agents"
+layout: layouts/post.njk
+teaser: "The follow-up I promised: real project-attached agent workflows, what they automate, and what surprised the people running them."
+date: 2026-06-24
+tags:
+  - posts
+topics:
+  - AI
+  - developer tools
+  - knowledge work
+kens_status: draft
+# TODO before publishing:
+#   - image + image_meta (see docs/IMAGE_GENERATION.md; woodcut style to match the series)
+#   - replace the [READER EXAMPLE] placeholders with collected submissions, or cut
+#     those sections and reframe as "my own field notes" if too few arrive
+#   - confirm date; this is a scheduled placeholder counted two weeks from drafting (10 June 2026)
+---
+
+{% markdown %}
+
+<!--
+== DRAFT SPEC ==
+
+Fulfills the promise made in 20260420-let-ai-worry-about-the-code.njk:
+"I would like to hear what you have automated and what surprised you.
+Drop me a note; I am collecting examples for a follow-up."
+
+Angle: not another "agents are great" piece. The previous post argued the
+productive pattern is a coding agent attached to a real project, primed with
+business context. This one is the evidence: concrete workflows, who runs them,
+and the recurring surprises. Audit context: five posts (four gears, four
+traditions, context-was-always-the-job, comprehension-debt, software-splits)
+establish the philosophy; none deliver the implementation layer. This post is
+the first step toward that playbook.
+
+Structure plan:
+1. Recap the question and why I asked it (2 short paragraphs)
+2. The patterns: 3-4 categories of automation that kept recurring
+3. The surprises: what people did not expect (the most shareable section)
+4. What this suggests about the playbook (bridge to a possible team-focused follow-up)
+5. Close: restate, invite more examples, related links
+
+Voice notes: zero em dashes (use colons, semicolons, commas). One-sentence
+teaser. Confident, evidence-led, no AI-boosterism. Keep under 1,500 words.
+-->
+
+In April I [asked what you had automated](/posts/20260420-let-ai-worry-about-the-code/) with coding agents attached to real projects, and what surprised you along the way. This post collects the answers, mine included.
+
+The short version: almost nobody automated the thing they set out to automate. The workflows that stuck were the ones discovered mid-project, where the agent was already primed with context for a different task and the automation fell out as a side effect.
+
+> **tl;dr**
+>
+> - **The recurring pattern**: automations that survive are project-attached, not task-attached; the context folder matters more than the prompt.
+> - **The common surprise**: the second version surprises you, not the first; first versions reliably underperform the manual process.
+> - **The dividing line holds**: every working example came from someone comfortable reading diffs, even when they wrote none of the code.
+
+## What I asked
+
+[TODO: brief recap of the original framing: comfort with the vernacular of code, the project folder as the unit of work, the GA4 MCP server example. Two paragraphs maximum; link back rather than re-explain.]
+
+## The patterns
+
+[READER EXAMPLE placeholders below; replace with real submissions. Keep 3-4 categories, one concrete example each, named or anonymized per submitter preference.]
+
+### Reporting that crosses tool boundaries
+
+My own canonical example: the [UNDRR analytics setup](/work/2026/impact-story-undrr-analytics-overlay-mcp/), where a local MCP server encodes what our GA4 data means and a local Drupal database lets the agent resolve ambiguous URLs itself. The investigation that used to be a tedious cross-tool query now runs in one pass.
+
+[READER EXAMPLE: similar cross-system reporting story from a different stack.]
+
+### Maintenance chores with judgment in the loop
+
+[READER EXAMPLE: dependency updates, content migrations, link checking; the interesting part is where people kept the human checkpoint.]
+
+### Context capture as automation
+
+[READER EXAMPLE: people who automated the writing-down, not the doing: changelogs, decision records, runbooks generated from the work itself. Connects to the comprehension-debt thread.]
+
+## What surprised people
+
+[TODO: this is the heart of the post. Candidate surprises from my own notes, to validate against submissions:]
+
+- First versions underperform; the payoff arrives on iteration two or three, after the context files improve. People who quit after one attempt concluded the whole approach fails.
+- Dictation beats typing for instructions. Looser, narrative input outperforms concise prompts.
+- The agent surfaces organizational ambiguity. When it asks "which of these three definitions of engagement do you mean?", that question was always there; nobody had to answer it before.
+
+## Toward a playbook
+
+[TODO: short bridge section. The examples suggest the implementation layer the earlier posts skipped: what a team's context folder should contain, who maintains it, how skills and MCP servers get reviewed. Decide whether that becomes its own post; if so, name it here as the next follow-up and keep this section to one paragraph.]
+
+## Keep them coming
+
+The pattern from the first post holds: the leverage lives where code lives, and the people getting it are credible readers and directors of what the agent produces, not necessarily writers of it. If your example is missing here, [drop me a note](/about/); I will keep adding to this collection.
+
+Related writing: [Let AI worry about the code, you worry about the work](/posts/20260420-let-ai-worry-about-the-code/), [Four gears of AI-assisted development](/posts/20260405-four-phases-of-ai-adoption/), and [why context engineering was always the job](/posts/20260330-context-was-always-the-job/).
+
+{% endmarkdown %}


### PR DESCRIPTION
## Summary

Spec'd draft of the follow-up promised in [Let AI worry about the code](https://allaboutken.com/posts/20260420-let-ai-worry-about-the-code/) ("I am collecting examples for a follow-up"). Scheduled date: **2026-06-24**, `kens_status: draft`.

## Status

- [x] Framing, tl;dr, structure, and closing written
- [x] UNDRR analytics example seeded in the patterns section
- [ ] Replace `[READER EXAMPLE]` placeholders with collected submissions (or reframe as personal field notes)
- [ ] Resolve `TODO` sections (recap, surprises validation, playbook bridge)
- [ ] Add image + `image_meta` (woodcut style, see `docs/IMAGE_GENERATION.md`)
- [ ] Set `kens_status` to `final_draft` and confirm date

## ⚠️ Do not merge yet

Future-dated posts render at build time and `kens_status` is tracking-only, so merging publishes the skeleton as-is.