### PR TITLE
chore: retire GitHub Pages CI deploy step

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Build
 on:
   pull_request:
     branches:
@@ -16,14 +16,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 permissions:
-  contents: write
-  pages: write
-  id-token: write
-# Allow one concurrent deployment
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
+  contents: read
 jobs:
+  # Build job — lints CSS and validates that the site compiles.
+  # Production deploys are handled by the Vercel GitHub App (see docs/DEPLOYMENT.md).
   build:
     concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
     runs-on: ubuntu-latest
@@ -42,21 +38,3 @@ jobs:
         continue-on-error: true
       - name: Build site 🔧
         run: yarn build
-      - name: Configure Pages
-        uses: actions/configure-pages@v6
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: build
-  # Deployment job
-  deploy:
-    if: github.ref == 'refs/heads/main' # only deploy if branch is master
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,4 +62,4 @@ When working on blog posts or impact stories, read the docs:
 
 ## Deployment
 
-GitHub Pages via GitHub Actions. Deploys on push to `main` when source files change. PRs trigger build checks but don't deploy. See `.github/workflows/build-and-deploy.yml`.
+Vercel serves the production site (`allaboutken.com`); the Vercel GitHub App auto-deploys on push to `main` and creates preview deployments for PRs. GitHub Actions (`.github/workflows/build-and-deploy.yml`) only runs a build check (lint + compile) — it no longer deploys. See `docs/DEPLOYMENT.md` for the full architecture.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -61,11 +61,11 @@ Current DNS records for the main site:
 
 Operational details for routes, local development, and wrangler usage are documented in [`worker/README.md`](../worker/README.md).
 
-### GitHub Pages — main site (warm spare) and hobby project origins
+### GitHub Pages — hobby project origins
 
 - **URL:** `khawkins98.github.io`
 
-**Main site:** GitHub Actions (`.github/workflows/build-and-deploy.yml`) still builds and deploys the main site to GitHub Pages on every push to `main`. This is currently a warm spare — `allaboutken.com` DNS now points to Vercel, so GitHub Pages is not receiving production traffic. See issue #62 for the planned cleanup.
+**Main site:** GitHub Pages is no longer used to serve the main site. `allaboutken.com` is served by Vercel, and the GitHub Actions workflow (`.github/workflows/build-and-deploy.yml`) now only runs a build check (lint + compile) on pushes and PRs — it no longer deploys to GitHub Pages. The `deploy` job was retired in issue #62. GitHub Pages can be left enabled in the repo Settings (harmless) or disabled; either way it receives no production traffic. If a rollback to GitHub Pages is ever needed, see "How to revert to GitHub Pages" below.
 
 **Hobby projects: do not disable GitHub Pages in these repos.** Each hobby project has its own repo with its own GitHub Pages deployment, and Vercel proxies to `khawkins98.github.io/project-name/` as the origin. If GitHub Pages is turned off in a hobby project repo, the proxied path on `allaboutken.com` will immediately 404. When adding a new hobby project, confirm GitHub Pages is enabled and the site is live at `khawkins98.github.io/repo-name/` *before* adding the rewrite to `vercel.json`.
 
@@ -146,11 +146,11 @@ If Vercel needs to be removed:
 
 | Trigger | What happens |
 |---------|-------------|
-| Push to `main` (source files changed) | GitHub Actions builds and deploys to GitHub Pages; Vercel GitHub App independently builds and deploys to Vercel production |
+| Push to `main` (source files changed) | GitHub Actions runs a build check (lint + compile); Vercel GitHub App independently builds and deploys to Vercel production |
 | Pull request | GitHub Actions runs a build check; Vercel creates a preview deployment |
-| Manual `workflow_dispatch` | Can trigger either workflow manually from the Actions tab |
+| Manual `workflow_dispatch` | Can trigger the build workflow manually from the Actions tab |
 
-The GitHub Pages deploy in CI is currently a warm spare. Consider removing the `deploy` job from `.github/workflows/build-and-deploy.yml` once confidence in Vercel is established.
+Production deploys are handled entirely by the Vercel GitHub App. The GitHub Actions workflow only validates the build; the GitHub Pages `deploy` job was retired in issue #62.
 
 ## Operational runbooks
 


### PR DESCRIPTION
Closes #62.

Now that `allaboutken.com` is served by Vercel, the GitHub Pages `deploy` job in the build workflow is a warm spare with no production traffic. This removes it.

## Changes

- **`.github/workflows/build-and-deploy.yml`** — removed the `deploy` job plus the Pages-only steps (`Configure Pages`, `Upload artifact`), the `pages`/`id-token` permissions, and the `pages` concurrency group. The workflow now only lints CSS and validates that the site builds (still runs on pushes and PRs). Renamed `Build and Deploy` → `Build`.
- **`docs/DEPLOYMENT.md`** — removed the "warm spare" language; clarified GitHub Pages is no longer used for the main site (hobby-project origins are unchanged). Updated the CI/CD summary table.
- **`CLAUDE.md`** — updated the Deployment section to reflect Vercel-only deploys.

## Notes

- The issue's optional step "disable GitHub Pages in repo Settings" is a manual UI action and is left to you — it's harmless either way.
- The "How to revert to GitHub Pages" runbook in `DEPLOYMENT.md` is intentionally kept as a rollback path.

## Test plan

- [ ] CI build check passes on this PR
- [ ] No `deploy` job appears in the Actions run

https://claude.ai/code/session_01SmFDfL4yuqEZqJWC8tn9qQ