### PR TITLE
ci: allow optional scope in PR title check

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -12,12 +12,14 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if echo "$PR_TITLE" | grep -qE "^(content|feature|fix|ci|chore): .+"; then
+          # Allow an optional conventional-commit scope, e.g. chore(deps):
+          # which is what Dependabot uses for all of its PR titles.
+          if echo "$PR_TITLE" | grep -qE "^(content|feature|fix|ci|chore)(\([a-z0-9 ._-]+\))?: .+"; then
             echo "✅ PR title OK: $PR_TITLE"
           else
             echo "❌ PR title must match the commit convention"
             echo ""
-            echo "   Expected:  <prefix>: <description>"
+            echo "   Expected:  <prefix>: <description>  (optional scope allowed, e.g. chore(deps):)"
             echo "   Prefixes:  content | feature | fix | ci | chore"
             echo ""
             echo "   Got:  $PR_TITLE"


### PR DESCRIPTION
## Why

`check-title` fails on **every** Dependabot PR. The regex in `pr-title-check.yml` was:

```
^(content|feature|fix|ci|chore): .+
```

It requires the prefix immediately followed by `: `. Dependabot always uses a conventional-commit scope — `chore(deps): bump…`, `chore(deps-dev): bump…` — and the `(deps)` breaks the match. Non-blocking, but it red-X'd every dependency PR.

## Fix

Allow an optional `(scope)` after the prefix:

```
^(content|feature|fix|ci|chore)(\([a-z0-9 ._-]+\))?: .+
```

Verified: `chore(deps):` and `chore(deps-dev):` now pass; plain `chore:`/`content:` still pass; `fix(worker):` passes; titles with no valid prefix still fail.

https://claude.ai/code/session_01SmFDfL4yuqEZqJWC8tn9qQ