### PR TITLE
chore: image perf hints and Atom feed logo (audit quick wins)

### DIFF
--- a/src/site/_includes/layouts/post.njk
+++ b/src/site/_includes/layouts/post.njk
@@ -29,7 +29,7 @@ templateEngineOverride: njk
     {% if image %}
     <figure class="kh-figure">
       {% if href %}<a href="{{ href }}">{% endif %}
-      <img class="kh-figure__image kh-figure__image--lead" src="/images{{ image | url }}" alt="{{ image_meta.altext or image_meta.alt or '' }}">
+      <img class="kh-figure__image kh-figure__image--lead" src="/images{{ image | url }}" alt="{{ image_meta.altext or image_meta.alt or '' }}" decoding="async" fetchpriority="high">
       {% if href %}</a>{% endif %}
       {% if image_meta and image_meta.credit %}
       <small class="kh-figure__credit">{{ image_meta.credit | safe }}</small>
@@ -101,7 +101,7 @@ templateEngineOverride: njk
             rel="nofollow" class="kh-button kh-button--sm">👍 This was useful</a>
         <!-- Feedback toast: see /posts/20260220-feedback-buttons-cgi-pattern/ -->
         <span id="thanks" class="kh-feedback-thanks" aria-live="polite">Thanks for the feedback! <a href="/posts/20260220-feedback-buttons-cgi-pattern/" class="kh-feedback-thanks__link">Curious how this was built?</a></span>
-        <span><img src="https://feedback.allaboutken.com/count{{ page.url }}.svg" alt="Feedback count" style="display:inline;vertical-align:middle;height:1.5em;max-width:none"> people found this useful</span>
+        <span><img src="https://feedback.allaboutken.com/count{{ page.url }}.svg" alt="Feedback count" loading="lazy" decoding="async" style="display:inline;vertical-align:middle;height:1.5em;max-width:none"> people found this useful</span>
         </p>
       </div>
     </div>

--- a/src/site/feed.njk
+++ b/src/site/feed.njk
@@ -16,6 +16,8 @@ metadata:
   <link href="{{ siteConfig.url }}"/>
   <updated>{{ collections.posts | rssLastUpdatedDate }}</updated>
   <id>{{ metadata.id | ensureTrailingSlash }}</id>
+  <logo>{{ metadata.id }}/assets/ken-favicon/assets/android-chrome-512x512.png</logo>
+  <icon>{{ metadata.id }}/assets/ken-favicon/assets/favicon-32x32.png</icon>
   <author>
     <name>{{ siteConfig.author }}</name>
     <email>{{ siteConfig.email }}</email>


### PR DESCRIPTION
Knocks out the remaining **Quick wins** from the 2026-05 audit (#56). The larger items there are each their own effort (see note below).

## Changes

**`post.njk` — manual `<img>` tags (the `eleventyImageTransformPlugin` attributes don't flow to these):**
- **Lead hero image:** added `decoding="async"` and `fetchpriority="high"`. Deliberately **not** `loading="lazy"` — the hero is above the fold and is the LCP element, so lazy-loading it would hurt Core Web Vitals (the opposite of the audit's perf intent).
- **Feedback count image** (below the fold, decorative): added `loading="lazy" decoding="async"`.

**`feed.njk` — feed logo:**
- Added `<logo>` (android-chrome-512×512) and `<icon>` (favicon-32×32). Note: this is an **Atom** feed, so the spec elements are `<logo>`/`<icon>` — the audit said `<image>`, which is the RSS 2.0 element and isn't valid in Atom. Both use absolute URLs.

## Not in this PR — recommend separate issues

The audit's "Larger / issue-worthy" items are each substantial and open-ended; better tracked individually:
- CI link validation (linkinator/broken-link-checker)
- Lighthouse/perf budget gate in CI
- Content QA pipeline (alt-text validator across posts)
- Build perf (embeddings model caching)
- Structured-data `dateModified` consistency + absolute image URLs
- Semantic-search first-load spinner + keyword fallback hardening

Happy to file these as individual issues if useful. The sitemap item was already done.

## Verification

- `yarn eleventy` builds clean
- `rss.xml` shows the `<logo>`/`<icon>`; hero img has `decoding`/`fetchpriority`; feedback img is lazy

Refs #56.

https://claude.ai/code/session_01SmFDfL4yuqEZqJWC8tn9qQ