### PR TITLE
ci: cache embedding model and add internal link validation

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,8 +33,24 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies 📦
         run: yarn install --frozen-lockfile
+      # Cache the embedding model so it doesn't re-download from HuggingFace
+      # on every build. Keyed on the embeddings script (which holds MODEL_NAME),
+      # so the cache busts automatically when the model changes.
+      - name: Cache embedding model 🧠
+        uses: actions/cache@v4
+        with:
+          path: .cache/transformers
+          key: transformers-model-${{ hashFiles('scripts/generate-embeddings.mjs') }}
+          restore-keys: |
+            transformers-model-
       - name: Lint CSS 🧹
         run: yarn lint:css
         continue-on-error: true
       - name: Build site 🔧
         run: yarn build
+      # Reports broken internal links/anchors in the build output. Non-blocking
+      # for now (like lint:css) until the existing catalog is confirmed clean;
+      # drop continue-on-error to make it a hard gate.
+      - name: Validate internal links 🔗
+        run: yarn lint:links
+        continue-on-error: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Exceptions and gotchas that aren't obvious from reading the code or existing doc
 yarn dev          # Development server (Sass watch + Eleventy --serve)
 yarn build        # Full production build (clean → sass → eleventy → embeddings)
 yarn lint:css     # Lint SCSS files
+yarn lint:links   # Validate internal links/anchors in build/ (run after a build)
 ```
 
 ## Gotchas
@@ -35,7 +36,7 @@ The directory `src/components/vf-componenet-rollup/` is a legacy name. The typo 
 The markdown-it config converts `--` to `—` automatically. Write `--` in content, it renders as `—`.
 
 ### Embeddings don't run in dev
-`yarn embeddings` is too slow for iterative development. Run `yarn build` once to generate `vectors.json`, then `yarn dev` as usual. The `@huggingface/transformers` devDependency is ~476 MB in node_modules (ONNX runtime ships native binaries for every platform). It's needed to run the model at build time -- there's no lighter alternative.
+`yarn embeddings` is too slow for iterative development. Run `yarn build` once to generate `vectors.json`, then `yarn dev` as usual. The `@huggingface/transformers` devDependency is ~476 MB in node_modules (ONNX runtime ships native binaries for every platform). It's needed to run the model at build time -- there's no lighter alternative. At build time the model itself is cached under `.cache/transformers` (set via `env.cacheDir` in `generate-embeddings.mjs`); CI restores that directory so the model is not re-downloaded from HuggingFace every run.
 
 ### Semantic search model loading
 The browser fetches the model directly from HuggingFace at query time. Transformers.js caches it using the Cache API (keyed by model ID, not URL), so the ~23 MB download only happens once per browser. Transformers.js and ONNX Runtime WASM load from jsDelivr.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ Most posts are practitioner-level takes and technical tutorials. The [Work secti
 
 ```bash
 yarn install
-yarn dev      # Sass watch + Eleventy --serve
-yarn build    # Full production build: clean → sass → eleventy → embeddings
-              # The embeddings step downloads ~476 MB of ONNX Runtime on first run for the build-time ML toolchain.
+yarn dev        # Sass watch + Eleventy --serve
+yarn build      # Full production build: clean → sass → eleventy → embeddings
+                # The embeddings step downloads ~476 MB of ONNX Runtime on first run for the build-time ML toolchain.
+                # The MiniLM model is cached under .cache/transformers (CI restores it between runs).
+yarn lint:links # Validate internal links/anchors in build/ (run after a build)
 ```
 
 ## Stack

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -146,7 +146,7 @@ If Vercel needs to be removed:
 
 | Trigger | What happens |
 |---------|-------------|
-| Push to `main` (source files changed) | GitHub Actions runs a build check (lint + compile); Vercel GitHub App independently builds and deploys to Vercel production |
+| Push to `main` (source files changed) | GitHub Actions runs a build check (lint CSS, compile, validate internal links); Vercel GitHub App independently builds and deploys to Vercel production |
 | Pull request | GitHub Actions runs a build check; Vercel creates a preview deployment |
 | Manual `workflow_dispatch` | Can trigger the build workflow manually from the Actions tab |
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -10,6 +10,7 @@ Source of truth for local commands and script behavior in this repository.
 | `yarn build` | Run full production build | Pre-push validation and CI parity |
 | `yarn embeddings` | Regenerate semantic-search vectors | After content/model changes that affect embeddings |
 | `yarn lint:css` | Lint SCSS/CSS files | Before committing style changes |
+| `yarn lint:links` | Validate internal links in `build/` | After a build, to catch broken internal links/anchors |
 
 ## Script details
 
@@ -39,11 +40,20 @@ Source of truth for local commands and script behavior in this repository.
 
 - Same scope as `yarn lint:css`, but with `--fix` for auto-fixable issues.
 
+### `yarn lint:links`
+
+- Runs `node scripts/check-links.mjs`.
+- Walks the `build/` output and verifies every **internal** link resolves to a real file (handling pretty URLs → `index.html`), and checks `#fragment` links against the target page's `id`/`name` attributes.
+- External links (`http(s)://`, protocol-relative, `mailto:`, `tel:`, `data:`) are skipped on purpose — they are non-deterministic in CI.
+- Requires a build first (run `yarn eleventy` or `yarn build`). Exits non-zero if any internal link is broken.
+- Runs in CI after the build (currently non-blocking; see `.github/workflows/build-and-deploy.yml`).
+
 ### `yarn embeddings`
 
 - Runs `node scripts/generate-embeddings.mjs`.
 - Reads generated HTML in `build/`, extracts searchable content, and writes `build/semantic-search/vectors.json`.
 - Intended to run after Eleventy has produced the site output.
+- Caches the downloaded MiniLM model under `.cache/transformers` (set via `env.cacheDir`). CI restores this directory between runs so the model is not re-downloaded from HuggingFace every build.
 
 ### `yarn build`
 
@@ -100,6 +110,11 @@ Source of truth for local commands and script behavior in this repository.
 ### `scripts/generate-embeddings.mjs`
 
 - Active build script used by `yarn embeddings` and `yarn build`.
+
+### `scripts/check-links.mjs`
+
+- Active script used by `yarn lint:links`.
+- Dependency-free internal-link and anchor validator for the `build/` output.
 
 ### `scripts/process-images.js`
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -45,6 +45,7 @@ Source of truth for local commands and script behavior in this repository.
 - Runs `node scripts/check-links.mjs`.
 - Walks the `build/` output and verifies every **internal** link resolves to a real file (handling pretty URLs → `index.html`), and checks `#fragment` links against the target page's `id`/`name` attributes.
 - External links (`http(s)://`, protocol-relative, `mailto:`, `tel:`, `data:`) are skipped on purpose — they are non-deterministic in CI.
+- Vercel-proxied hobby-project prefixes (read from `vercel.json` rewrites, e.g. `/PDF-A-go-go/`, `/pinment/`) are skipped too — they resolve in production via proxy but are absent from the local build. `<script>`/`<style>` bodies are stripped before scanning so JS template strings aren't treated as links.
 - Requires a build first (run `yarn eleventy` or `yarn build`). Exits non-zero if any internal link is broken.
 - Runs in CI after the build (currently non-blocking; see `.github/workflows/build-and-deploy.yml`).
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eleventy": "ELEVENTY_ENV=production eleventy --config=eleventy.js",
     "lint:css": "stylelint \"src/**/*.scss\" \"src/**/*.css\"",
     "lint:css:fix": "stylelint \"src/**/*.scss\" \"src/**/*.css\" --fix",
+    "lint:links": "node scripts/check-links.mjs",
     "embeddings": "node scripts/generate-embeddings.mjs",
     "build": "yarn clean && yarn sass && yarn eleventy && yarn embeddings && echo '🏋 Build completed'",
     "dev": "concurrently -k \"sass --load-path src/components --watch --poll src/components/vf-componenet-rollup/index.scss:build/css/styles.css\" \"ELEVENTY_ENV=development eleventy --serve --config=eleventy.js\"",

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -22,6 +22,22 @@ const BUILD_DIR = 'build';
 // Links we never resolve on disk.
 const EXTERNAL = /^(https?:|\/\/|mailto:|tel:|data:|javascript:|#)/i;
 
+// Path prefixes served by Vercel rewrites to external origins (hobby projects
+// proxied to GitHub Pages). They are valid in production but absent from the
+// local build, so resolving them on disk would be a false positive. Derived
+// from vercel.json rewrites, e.g. "/PDF-A-go-go/:path*" -> "/PDF-A-go-go/".
+function proxiedPrefixes() {
+  try {
+    const cfg = JSON.parse(readFileSync('vercel.json', 'utf-8'));
+    return (cfg.rewrites || [])
+      .map(r => (r.source || '').split(':')[0]) // strip ":path*"
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+const PROXIED = proxiedPrefixes();
+
 function findHtmlFiles(dir, files = []) {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
@@ -32,13 +48,19 @@ function findHtmlFiles(dir, files = []) {
 }
 
 // Extract href="..." and src="..." values (single or double quoted).
+// Strips <script>/<style> first so JS template strings (e.g. `${item.url}`)
+// aren't mistaken for links.
 function extractLinks(html) {
+  const cleaned = html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '');
   const links = [];
   const re = /(?:href|src)\s*=\s*("([^"]*)"|'([^']*)')/gi;
   let m;
-  while ((m = re.exec(html)) !== null) {
+  while ((m = re.exec(cleaned)) !== null) {
     const val = (m[2] ?? m[3] ?? '').trim();
-    if (val) links.push(val);
+    // Skip empty and unresolved template artifacts (e.g. `${...}`).
+    if (val && !val.includes('${')) links.push(val);
   }
   return links;
 }
@@ -105,6 +127,8 @@ function main() {
     const html = readFileSync(file, 'utf-8');
     for (const link of extractLinks(html)) {
       if (EXTERNAL.test(link)) continue;
+      // Skip Vercel-proxied hobby-project paths (valid in prod, not in build).
+      if (PROXIED.some(p => link === p || link.startsWith(p))) continue;
       checked++;
 
       const target = resolveTarget(link, file);

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,146 @@
+/**
+ * Validate internal links in the built site.
+ *
+ * Walks build/**\/*.html, extracts every href/src, and for each internal
+ * link checks that the target file exists in the build output. For internal
+ * links that include a #fragment, it also checks that an element with a
+ * matching id (or name) exists on the target page.
+ *
+ * External links (http/https/protocol-relative/mailto/tel/data) are skipped
+ * deliberately: they are non-deterministic in CI (rate limits, transient
+ * outages) and not something a build can guarantee. This check is about
+ * catching broken internal links and anchors, which a build *can* guarantee.
+ *
+ * Exits non-zero if any broken internal link is found. Run after `yarn eleventy`.
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
+import { join, relative, dirname, resolve, extname } from 'path';
+
+const BUILD_DIR = 'build';
+
+// Links we never resolve on disk.
+const EXTERNAL = /^(https?:|\/\/|mailto:|tel:|data:|javascript:|#)/i;
+
+function findHtmlFiles(dir, files = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) findHtmlFiles(full, files);
+    else if (entry.endsWith('.html')) files.push(full);
+  }
+  return files;
+}
+
+// Extract href="..." and src="..." values (single or double quoted).
+function extractLinks(html) {
+  const links = [];
+  const re = /(?:href|src)\s*=\s*("([^"]*)"|'([^']*)')/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const val = (m[2] ?? m[3] ?? '').trim();
+    if (val) links.push(val);
+  }
+  return links;
+}
+
+// Does the target HTML contain an element with id="frag" or name="frag"?
+function hasAnchor(html, frag) {
+  const f = frag.replace(/"/g, '');
+  const idRe = new RegExp(`\\b(?:id|name)\\s*=\\s*["']${escapeRegex(f)}["']`, 'i');
+  return idRe.test(html);
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Resolve a link to a candidate file path inside the build dir.
+// Returns the resolved absolute-ish path under BUILD_DIR, or null if it
+// escapes the build root.
+function resolveTarget(link, fromFile) {
+  let pathPart = link.split('#')[0].split('?')[0];
+  if (pathPart === '') return null; // pure fragment / query, handled by caller
+
+  let abs;
+  if (pathPart.startsWith('/')) {
+    abs = join(BUILD_DIR, pathPart);
+  } else {
+    abs = join(dirname(fromFile), pathPart);
+  }
+  abs = resolve(abs);
+  const root = resolve(BUILD_DIR);
+  if (abs !== root && !abs.startsWith(root + '/')) return null; // escapes build/
+  return abs;
+}
+
+// Given a resolved path, find the actual file on disk (handling pretty URLs).
+function locateFile(abs) {
+  if (existsSync(abs) && statSync(abs).isFile()) return abs;
+  // Directory or pretty URL → index.html
+  if (existsSync(abs) && statSync(abs).isDirectory()) {
+    const idx = join(abs, 'index.html');
+    if (existsSync(idx)) return idx;
+  }
+  // Extensionless pretty URL → try /index.html or .html
+  if (!extname(abs)) {
+    const idx = join(abs, 'index.html');
+    if (existsSync(idx)) return idx;
+    const html = abs + '.html';
+    if (existsSync(html)) return html;
+  }
+  return null;
+}
+
+function main() {
+  if (!existsSync(BUILD_DIR)) {
+    console.error(`Build directory "${BUILD_DIR}/" not found. Run \`yarn eleventy\` first.`);
+    process.exit(1);
+  }
+
+  const files = findHtmlFiles(BUILD_DIR);
+  const broken = [];
+  let checked = 0;
+
+  for (const file of files) {
+    const html = readFileSync(file, 'utf-8');
+    for (const link of extractLinks(html)) {
+      if (EXTERNAL.test(link)) continue;
+      checked++;
+
+      const target = resolveTarget(link, file);
+      if (target === null) {
+        broken.push({ file, link, reason: 'escapes build root or unresolvable' });
+        continue;
+      }
+
+      const located = locateFile(target);
+      if (!located) {
+        broken.push({ file, link, reason: 'target file not found' });
+        continue;
+      }
+
+      // Anchor check
+      const hash = link.includes('#') ? link.split('#')[1] : '';
+      if (hash && located.endsWith('.html')) {
+        const targetHtml = readFileSync(located, 'utf-8');
+        if (!hasAnchor(targetHtml, hash)) {
+          broken.push({ file, link, reason: `no element with id/name "${hash}"` });
+        }
+      }
+    }
+  }
+
+  console.log(`Checked ${checked} internal links across ${files.length} pages.`);
+
+  if (broken.length > 0) {
+    console.error(`\n❌ ${broken.length} broken internal link(s):\n`);
+    for (const b of broken) {
+      console.error(`  ${relative(BUILD_DIR, b.file)}\n    → ${b.link}  (${b.reason})`);
+    }
+    process.exit(1);
+  }
+
+  console.log('✅ No broken internal links.');
+}
+
+main();

--- a/scripts/generate-embeddings.mjs
+++ b/scripts/generate-embeddings.mjs
@@ -18,9 +18,14 @@
  *      for compatible models (look for ONNX exports with sentence-transformers)
  */
 
-import { pipeline } from '@huggingface/transformers';
+import { pipeline, env } from '@huggingface/transformers';
 import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'fs';
 import { join, relative } from 'path';
+
+// Cache downloaded model files in a stable, repo-local directory so CI can
+// restore them between builds (see actions/cache in build-and-deploy.yml).
+// Without this, the model re-downloads from HuggingFace on every build.
+env.cacheDir = '.cache/transformers';
 
 const BUILD_DIR = 'build';
 const OUTPUT_DIR = join(BUILD_DIR, 'semantic-search');


### PR DESCRIPTION
Tackles two of the "Larger / issue-worthy" items from the 2026-05 audit (#56): **build performance (embeddings caching)** and **CI link validation**.

## Build perf — embeddings model caching

The MiniLM model re-downloaded from HuggingFace on every build. Now:
- `scripts/generate-embeddings.mjs` pins the transformers.js cache to a stable `.cache/transformers` dir.
- The build workflow restores it via `actions/cache`, keyed on `scripts/generate-embeddings.mjs` (which holds `MODEL_NAME`), so the cache busts automatically when the model changes.

(The 476 MB ONNX native binaries are already covered by the existing setup-node yarn cache; this covers the separate model-file download.)

## Link validation — `scripts/check-links.mjs`

A small, dependency-free checker that walks the build output, verifies every **internal** link resolves to a real file (handling pretty URLs → `index.html`), and checks `#fragments` against the target page's `id`/`name` attributes. External links are skipped deliberately (rate limits / transient outages make them non-deterministic in CI). Run via `yarn lint:links`.

### Why not linkinator?

I tried linkinator first (both v6 and v7). Under Node 22 here it silently extracts **zero** links — verified on a trivial `<a href>` fixture and a live URL, so it's not an environment fluke; it would "pass" everything and be useless as a gate. The custom script is ~120 lines, has no flaky network deps, is verifiable locally, and additionally validates internal anchors (which linkinator doesn't). The audit named linkinator/broken-link-checker as examples; this meets the same goal more reliably.

### Non-blocking for now

Wired into CI as `continue-on-error: true`, matching how `lint:css` is treated, because I couldn't complete a full local production build to confirm the existing internal-link catalog is 100% clean (the `yarn clean` cache wipe makes the image step very slow locally). Flipping it to a hard gate is a one-line change (drop `continue-on-error`) once a clean run is confirmed in CI.

## Verification notes

- `check-links.mjs` logic confirmed against the build: the only items it flagged were false positives from an **incomplete** local build (CSS not yet generated, posts/impact-stories not yet written) — all of those targets exist in source with correct permalinks.
- Embeddings cache-dir change is low-risk (just sets `env.cacheDir`); worth confirming on the next CI/Vercel build.

Refs #56.

https://claude.ai/code/session_01SmFDfL4yuqEZqJWC8tn9qQ