### PR TITLE
fix: SCSS lint cleanup and link checker fixes

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -2,6 +2,8 @@
 
 This directory contains shared git hooks for the repository. They are configured to run automatically when you use git commands.
 
+Canonical documentation for hook behavior and troubleshooting lives in [`docs/GIT_HOOKS.md`](../docs/GIT_HOOKS.md).
+
 ## Setup
 
 Hooks are automatically enabled via `core.hooksPath`. If you haven't already, run:
@@ -16,17 +18,19 @@ git config core.hooksPath .githooks
 
 Reminds you about PR title format requirements before pushing. This helps catch issues early that would otherwise fail in the `pr-title-check` GitHub Actions workflow.
 
-**Required format:**
+**Required CI format:**
 ```
 <prefix>: <description>
 ```
 
 **Valid prefixes:** `content`, `feature`, `fix`, `ci`, `chore`
+**Optional scope:** `chore(deps): <description>` is allowed
 
 **Examples:**
 - ✓ `content: New blog post on editorial AI`
 - ✓ `feature: Add semantic search to posts`
 - ✓ `fix: Correct image paths in 2025 posts`
+- ✓ `chore(deps): Upgrade pagefind and regenerate vectors.`
 - ✗ `Editorial AI Framework: Three interconnected posts` ← fails check
 - ✗ `Add verify-contracts script and wire into CI` ← fails check
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,8 +33,24 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies 📦
         run: yarn install --frozen-lockfile
+      # Cache the embedding model so it doesn't re-download from HuggingFace
+      # on every build. Keyed on the embeddings script (which holds MODEL_NAME),
+      # so the cache busts automatically when the model changes.
+      - name: Cache embedding model 🧠
+        uses: actions/cache@v4
+        with:
+          path: .cache/transformers
+          key: transformers-model-${{ hashFiles('scripts/generate-embeddings.mjs') }}
+          restore-keys: |
+            transformers-model-
       - name: Lint CSS 🧹
         run: yarn lint:css
         continue-on-error: true
       - name: Build site 🔧
         run: yarn build
+      # Reports broken internal links/anchors in the build output. Non-blocking
+      # for now (like lint:css) until the existing catalog is confirmed clean;
+      # drop continue-on-error to make it a hard gate.
+      - name: Validate internal links 🔗
+        run: yarn lint:links
+        continue-on-error: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Exceptions and gotchas that aren't obvious from reading the code or existing doc
 yarn dev          # Development server (Sass watch + Eleventy --serve)
 yarn build        # Full production build (clean → sass → eleventy → embeddings)
 yarn lint:css     # Lint SCSS files
+yarn lint:links   # Validate internal links/anchors in build/ (run after a build)
 ```
 
 ## Gotchas
@@ -35,7 +36,7 @@ The directory `src/components/vf-componenet-rollup/` is a legacy name. The typo 
 The markdown-it config converts `--` to `—` automatically. Write `--` in content, it renders as `—`.
 
 ### Embeddings don't run in dev
-`yarn embeddings` is too slow for iterative development. Run `yarn build` once to generate `vectors.json`, then `yarn dev` as usual. The `@huggingface/transformers` devDependency is ~476 MB in node_modules (ONNX runtime ships native binaries for every platform). It's needed to run the model at build time -- there's no lighter alternative.
+`yarn embeddings` is too slow for iterative development. Run `yarn build` once to generate `vectors.json`, then `yarn dev` as usual. The `@huggingface/transformers` devDependency is ~476 MB in node_modules (ONNX runtime ships native binaries for every platform). It's needed to run the model at build time -- there's no lighter alternative. At build time the model itself is cached under `.cache/transformers` (set via `env.cacheDir` in `generate-embeddings.mjs`); CI restores that directory so the model is not re-downloaded from HuggingFace every run.
 
 ### Semantic search model loading
 The browser fetches the model directly from HuggingFace at query time. Transformers.js caches it using the Cache API (keyed by model ID, not URL), so the ~23 MB download only happens once per browser. Transformers.js and ONNX Runtime WASM load from jsDelivr.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,13 +45,13 @@ Examples:
 - One logical change per commit
 - Never use `--no-verify` or `--no-gpg-sign` to bypass hooks
 
-The format is enforced locally by `.githooks/commit-msg` (activated on `yarn install` via the `prepare` script) and on PRs by the `pr-title-check` GitHub Actions workflow.
+Commit subjects are enforced locally by `.githooks/commit-msg` (activated on `yarn install` via the `prepare` script). PR titles are enforced in CI by `pr-title-check` for prefix/pattern matching.
 
 ## Pull requests
 
 One PR per unit of work. Keep noisy refactors out of content PRs.
 
-**Title**: same conventions as commit messages. Under 70 characters.
+**Title**: must match CI's enforced pattern (`<prefix>: <description>`) using prefixes `content|feature|fix|ci|chore`. Optional scope is allowed (for example, `chore(deps): ...`).
 
 **Body**: use [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). Two sections:
 
@@ -82,6 +82,8 @@ Always merge through a PR, even for solo work. Don't push directly to `main`. Re
 ## References
 
 - [`CLAUDE.md`](CLAUDE.md): project-specific gotchas (image paths, embeddings, CSS toggle scoping, the intentional typo in `vf-componenet-rollup`)
+- [`docs/GIT_HOOKS.md`](docs/GIT_HOOKS.md): hook setup, commit/PR title rules, and troubleshooting
+- [`docs/FONTS.md`](docs/FONTS.md): Recursive asset placement and `@font-face`/passthrough wiring
 - [`docs/PUBLISHING_WORKFLOW.md`](docs/PUBLISHING_WORKFLOW.md): editorial review stages and roles
 - [`src/site/style-guide/editorial.njk`](src/site/style-guide/editorial.njk): voice, tone, structure
 - [`docs/IMAGE_GENERATION.md`](docs/IMAGE_GENERATION.md): hero image pipeline

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ eleventy.js       All config: filters, shortcodes, collections, image transform
 
 For the full stack breakdown and design principles, see the [colophon](https://www.allaboutken.com/colophon/).
 For contribution workflow and commit/PR conventions, see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+For hook setup and commit/PR title enforcement details, see [`docs/GIT_HOOKS.md`](docs/GIT_HOOKS.md).
+For font asset placement and build wiring, see [`docs/FONTS.md`](docs/FONTS.md).
+For offline/service-worker architecture and cache behavior, see [`docs/OFFLINE_SERVICE_WORKER.md`](docs/OFFLINE_SERVICE_WORKER.md).
 For the full documentation map, see [`docs/README.md`](docs/README.md).
 For command behavior and script lifecycle details, see [`docs/SCRIPTS.md`](docs/SCRIPTS.md).
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ Most posts are practitioner-level takes and technical tutorials. The [Work secti
 
 ```bash
 yarn install
-yarn dev      # Sass watch + Eleventy --serve
-yarn build    # Full production build: clean → sass → eleventy → embeddings
-              # The embeddings step downloads ~476 MB of ONNX Runtime on first run for the build-time ML toolchain.
+yarn dev        # Sass watch + Eleventy --serve
+yarn build      # Full production build: clean → sass → eleventy → embeddings
+                # The embeddings step downloads ~476 MB of ONNX Runtime on first run for the build-time ML toolchain.
+                # The MiniLM model is cached under .cache/transformers (CI restores it between runs).
+yarn lint:links # Validate internal links/anchors in build/ (run after a build)
 ```
 
 ## Stack

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -146,7 +146,7 @@ If Vercel needs to be removed:
 
 | Trigger | What happens |
 |---------|-------------|
-| Push to `main` (source files changed) | GitHub Actions runs a build check (lint + compile); Vercel GitHub App independently builds and deploys to Vercel production |
+| Push to `main` (source files changed) | GitHub Actions runs a build check (lint CSS, compile, validate internal links); Vercel GitHub App independently builds and deploys to Vercel production |
 | Pull request | GitHub Actions runs a build check; Vercel creates a preview deployment |
 | Manual `workflow_dispatch` | Can trigger the build workflow manually from the Actions tab |
 

--- a/docs/DEVELOPMENT_SETUP.md
+++ b/docs/DEVELOPMENT_SETUP.md
@@ -84,6 +84,16 @@ yarn build
 
 to refresh `build/semantic-search/vectors.json`.
 
+### Service worker changes do not appear immediately
+
+Service workers can continue serving cached responses until the updated worker takes control. After changing `src/site/sw.js` or registration in `src/site/scripts.js`:
+
+```bash
+yarn build
+```
+
+Then hard refresh the browser tab once so the latest worker is activated for that client session.
+
 ### Build feels slow on first full run
 
 Expected: `@huggingface/transformers` and ONNX runtime assets make first-time setup heavy.
@@ -92,4 +102,5 @@ Expected: `@huggingface/transformers` and ONNX runtime assets make first-time se
 
 - [`SCRIPTS.md`](SCRIPTS.md) — command behavior details
 - [`ELEVENTY_CONFIG.md`](ELEVENTY_CONFIG.md) — filters/shortcodes/collections/passthrough rules
+- [`OFFLINE_SERVICE_WORKER.md`](OFFLINE_SERVICE_WORKER.md) — offline/service-worker architecture and cache behavior
 - [`CONTRIBUTING.md`](../CONTRIBUTING.md) — branch, commit, and PR conventions

--- a/docs/ELEVENTY_CONFIG.md
+++ b/docs/ELEVENTY_CONFIG.md
@@ -287,6 +287,8 @@ Used in `base.njk` to auto-generate `og:image` and `twitter:image` when no expli
 
 **Watch target:** `./src/site/images` — Eleventy watches this directory for changes in dev so image updates trigger rebuilds.
 
+**Service worker note:** because `./src/site/**/*.js` is passthrough-copied, `src/site/sw.js` is emitted as `/sw.js` (root URL), which matches registration in `src/site/scripts.js` (`navigator.serviceWorker.register('/sw.js', { scope: '/' })`). See [`OFFLINE_SERVICE_WORKER.md`](OFFLINE_SERVICE_WORKER.md) for runtime/offline behavior details.
+
 ---
 
 ## Section 8 — Pagefind hook

--- a/docs/FONTS.md
+++ b/docs/FONTS.md
@@ -1,0 +1,62 @@
+# Fonts
+
+Canonical reference for self-hosted webfont assets and build wiring.
+
+## Recursive font location
+
+Store Recursive assets in:
+
+- [`src/components/kh-font/`](../src/components/kh-font/)
+
+Current active file in CSS:
+
+- `Recursive_VF_1.085--subset-GF_latin_basic.woff2`
+
+## How font assets reach production
+
+Eleventy passthrough copies the whole font directory into the build output:
+
+- Source: `./src/components/kh-font`
+- Output: `build/assets/kh-font`
+- Config location: [`eleventy.js`](../eleventy.js) via `addPassthroughCopy({ "./src/components/kh-font": "assets/kh-font" })`
+
+## CSS integration
+
+The `@font-face` rule lives in:
+
+- [`src/components/vf-componenet-rollup/index.scss`](../src/components/vf-componenet-rollup/index.scss)
+
+It currently points to:
+
+```scss
+src: url('/assets/kh-font/Recursive_VF_1.085--subset-GF_latin_basic.woff2') format('woff2');
+```
+
+If you change filenames, update this path to match exactly.
+
+## Verification steps
+
+1. Build the site:
+
+   ```bash
+   yarn build
+   ```
+
+2. Confirm output file exists:
+
+   ```bash
+   ls build/assets/kh-font
+   ```
+
+3. Confirm compiled CSS references `/assets/kh-font/...`:
+
+   ```bash
+   rg "/assets/kh-font/" build/css/styles.css
+   ```
+
+4. In local preview (`yarn dev`), verify the page loads without 404s for the font URL in browser devtools.
+
+## Notes
+
+- `Recursive.woff2` may exist in the asset directory for fallback/experiments, but only the filename referenced in `@font-face` is used.
+- Keep fonts self-hosted in `src/components/kh-font/`; do not rely on runtime CDN font URLs for primary rendering.

--- a/docs/GIT_HOOKS.md
+++ b/docs/GIT_HOOKS.md
@@ -1,0 +1,69 @@
+# Git hooks
+
+Canonical reference for local Git hook behavior in this repository.
+
+## How hooks are enabled
+
+- This repo stores hooks in [`.githooks/`](../.githooks/).
+- `yarn install` runs `yarn prepare`, which sets:
+  - `git config core.hooksPath .githooks`
+- If hooks are not active, run this manually from the repo root:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+## Active hooks
+
+### `.githooks/commit-msg` (enforced)
+
+Checks the commit subject against:
+
+- Pattern: `<prefix>: <description>`
+- Allowed prefixes: `content`, `feature`, `fix`, `ci`, `chore`
+- Subject length: `<= 72` characters
+- No trailing period
+- Merge/revert/fixup/squash subjects are skipped
+
+### `.githooks/pre-push` (advisory)
+
+Prints pull request title format guidance before push. It does not block the push; CI is the enforcement source of truth.
+
+## PR title enforcement in CI
+
+GitHub Actions enforces PR titles in [`.github/workflows/pr-title-check.yml`](../.github/workflows/pr-title-check.yml):
+
+- Pattern: `<prefix>: <description>` (optional scope allowed, for example `chore(deps): ...`)
+- Allowed prefixes: `content`, `feature`, `fix`, `ci`, `chore`
+
+The workflow does **not** enforce maximum title length or trailing punctuation.
+
+## Troubleshooting
+
+### Hooks are not running
+
+1. Confirm hooks path:
+
+   ```bash
+   git config --get core.hooksPath
+   ```
+
+   Expected output: `.githooks`
+
+2. Re-run setup:
+
+   ```bash
+   yarn prepare
+   ```
+
+3. Ensure hook files are executable:
+
+   ```bash
+   ls -l .githooks
+   ```
+
+   You should see executable permissions on hook files (`commit-msg`, `pre-push`).
+
+### CI fails PR title check but local commits succeed
+
+The commit hook validates commit subjects; CI validates the **PR title** separately. Update the PR title in GitHub to match the same `<prefix>: <description>` convention.

--- a/docs/OFFLINE_SERVICE_WORKER.md
+++ b/docs/OFFLINE_SERVICE_WORKER.md
@@ -1,0 +1,54 @@
+# Offline and service worker behavior
+
+Source files:
+
+- `src/site/sw.js` — service worker lifecycle, fetch handling, and cache updates
+- `src/site/scripts.js` — client-side service worker registration
+- `eleventy.js` — passthrough copy for `src/site/**/*.js` so `sw.js` is available at `/sw.js`
+
+## Architecture summary
+
+The site uses a single service worker (`/sw.js`) registered from `src/site/scripts.js` with:
+
+- `scope: '/'`
+- unconditional registration attempt when `navigator.serviceWorker` exists
+
+The worker uses one Cache Storage bucket:
+
+- Cache name: `pwabuilder-offline`
+- Install pre-cache target: `index.html`
+
+## Runtime behavior
+
+`src/site/sw.js` implements a network-first strategy for all `GET` requests:
+
+1. It tries `fetch(event.request)`.
+2. On success, it stores a cloned response in `pwabuilder-offline` via `cache.put(request, response.clone())`.
+3. On network failure, it tries to satisfy the request from the cache (`cache.match(request)`).
+4. If there is no cache hit, it rejects with `no-match` (there is no custom offline error page response today).
+
+Worker lifecycle behavior:
+
+- `install`: opens `pwabuilder-offline`, caches `index.html`, and calls `self.skipWaiting()`
+- `activate`: calls `self.clients.claim()` so the new worker controls pages without waiting for a full tab restart
+
+## Current limitations
+
+- The fallback constant is `index.html`, but fallback behavior is effectively "cached request only." If a request was never cached and the network is unavailable, it fails.
+- There is no route-specific offline shell and no custom offline page response in `fromCache`.
+- The cache is unversioned (`pwabuilder-offline`), so stale assets can persist until replaced by successful network responses.
+- Only successful `GET` responses are cached; non-GET traffic is ignored.
+
+## Safe update workflow
+
+When changing offline behavior:
+
+1. Update `src/site/sw.js` (and `src/site/scripts.js` if registration/scope changes).
+2. Run `yarn build` so generated output reflects current worker and asset references.
+3. Hard refresh once after deploy to ensure clients pick up the newest worker quickly.
+4. If cache schema/keys change, bump the cache name in `sw.js` and handle cleanup in `activate` before rollout.
+
+## Related docs
+
+- [`ELEVENTY_CONFIG.md`](ELEVENTY_CONFIG.md) for passthrough copy details that expose `sw.js` at the site root
+- [`DEVELOPMENT_SETUP.md`](DEVELOPMENT_SETUP.md) for local workflow and troubleshooting context

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,9 @@ Use this page as the entry point for repository documentation. It maps each doc 
 | --- | --- | --- | --- |
 | [`../README.md`](../README.md) | Project overview, stack, and quick start | Anyone entering the repo | You are orienting or setting up local dev |
 | [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Branch, commit, and PR conventions | Contributors and assistants | You are preparing commits, PR titles, and merge flow |
+| [`GIT_HOOKS.md`](GIT_HOOKS.md) | Local hook behavior, commit/PR title enforcement, and troubleshooting | Contributors and maintainers | You need to set up hooks or debug local vs CI title/commit checks |
 | [`SCRIPTS.md`](SCRIPTS.md) | Source of truth for `package.json` scripts and lifecycle behavior | Contributors running local/CI commands | You need the right command and expected output |
+| [`FONTS.md`](FONTS.md) | Recursive font asset placement, build passthrough, and verification | Contributors editing typography or static assets | You are changing font files or `@font-face` wiring |
 | [`DEPLOYMENT.md`](DEPLOYMENT.md) | Runtime architecture and platform ownership (Vercel, DNS, Pages, Worker) | Maintainer/operators | You are changing deploy config, DNS, or rewrites |
 | [`SEARCH.md`](SEARCH.md) | Keyword and semantic search architecture | Contributors touching search/indexing | You are changing Pagefind, embeddings, or search UI |
 | [`CSS_ARCHITECTURE.md`](CSS_ARCHITECTURE.md) | Sass structure and CSS toggle constraints | Contributors editing styles | You are adding or refactoring SCSS |
@@ -25,12 +27,14 @@ Use this page as the entry point for repository documentation. It maps each doc 
 | [`TEMPLATES.md`](TEMPLATES.md) | Layout hierarchy, partials, macros, and Nunjucks patterns used in site templates | Contributors changing page/layout templates | You are adding a page template, editing layouts, or tracing where markup is shared |
 | [`COMPONENTS.md`](COMPONENTS.md) | Component directory structure and Sass/asset build wiring | Contributors editing UI components and styles | You are adding/changing SCSS modules, assets, or component markup |
 | [`DEVELOPMENT_SETUP.md`](DEVELOPMENT_SETUP.md) | Local environment setup, Node/Yarn baseline, and troubleshooting | New contributors and maintainers | You need a reliable local dev environment or need to fix setup issues quickly |
+| [`OFFLINE_SERVICE_WORKER.md`](OFFLINE_SERVICE_WORKER.md) | Offline/service-worker runtime behavior, caching, and update safety notes | Contributors touching service worker behavior or static asset delivery | You are changing `sw.js`, registration flow, or offline cache strategy |
 
 ## Suggested read paths
 
-- **New contributor:** `../README.md` -> `../CONTRIBUTING.md` -> `SCRIPTS.md`
+- **New contributor:** `../README.md` -> `../CONTRIBUTING.md` -> `GIT_HOOKS.md` -> `SCRIPTS.md`
 - **Template work:** `TEMPLATES.md` -> `FRONTMATTER.md` -> `ELEVENTY_CONFIG.md`
-- **Component work:** `COMPONENTS.md` -> `CSS_ARCHITECTURE.md` -> `ELEVENTY_CONFIG.md`
+- **Component work:** `COMPONENTS.md` -> `CSS_ARCHITECTURE.md` -> `FONTS.md` -> `ELEVENTY_CONFIG.md`
 - **Local setup/debugging:** `DEVELOPMENT_SETUP.md` -> `SCRIPTS.md`
+- **Offline behavior:** `OFFLINE_SERVICE_WORKER.md` -> `ELEVENTY_CONFIG.md` -> `DEVELOPMENT_SETUP.md`
 - **Content workflow:** `PUBLISHING_WORKFLOW.md` -> `../src/site/style-guide/editorial.njk` -> `IMAGE_GENERATION.md`
 - **Operations/deploy:** `DEPLOYMENT.md` -> `../worker/README.md`

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -100,7 +100,7 @@ Source of truth for local commands and script behavior in this repository.
 - Allowed prefixes: `content`, `feature`, `fix`, `ci`, `chore`.
 - Enforces subject length <= 72 characters and disallows a trailing period.
 - Skips merge/revert/fixup/squash commit subjects.
-- Same convention is checked in CI for pull request titles by `.github/workflows/pr-title-check.yml`.
+- CI checks PR titles in `.github/workflows/pr-title-check.yml` for the same prefix/pattern (`<prefix>: <description>`, optional scope allowed), but does not enforce commit-subject length/punctuation rules.
 
 ### `yarn update-components`
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -10,6 +10,7 @@ Source of truth for local commands and script behavior in this repository.
 | `yarn build` | Run full production build | Pre-push validation and CI parity |
 | `yarn embeddings` | Regenerate semantic-search vectors | After content/model changes that affect embeddings |
 | `yarn lint:css` | Lint SCSS/CSS files | Before committing style changes |
+| `yarn lint:links` | Validate internal links in `build/` | After a build, to catch broken internal links/anchors |
 
 ## Script details
 
@@ -39,11 +40,20 @@ Source of truth for local commands and script behavior in this repository.
 
 - Same scope as `yarn lint:css`, but with `--fix` for auto-fixable issues.
 
+### `yarn lint:links`
+
+- Runs `node scripts/check-links.mjs`.
+- Walks the `build/` output and verifies every **internal** link resolves to a real file (handling pretty URLs → `index.html`), and checks `#fragment` links against the target page's `id`/`name` attributes.
+- External links (`http(s)://`, protocol-relative, `mailto:`, `tel:`, `data:`) are skipped on purpose — they are non-deterministic in CI.
+- Requires a build first (run `yarn eleventy` or `yarn build`). Exits non-zero if any internal link is broken.
+- Runs in CI after the build (currently non-blocking; see `.github/workflows/build-and-deploy.yml`).
+
 ### `yarn embeddings`
 
 - Runs `node scripts/generate-embeddings.mjs`.
 - Reads generated HTML in `build/`, extracts searchable content, and writes `build/semantic-search/vectors.json`.
 - Intended to run after Eleventy has produced the site output.
+- Caches the downloaded MiniLM model under `.cache/transformers` (set via `env.cacheDir`). CI restores this directory between runs so the model is not re-downloaded from HuggingFace every build.
 
 ### `yarn build`
 
@@ -100,6 +110,11 @@ Source of truth for local commands and script behavior in this repository.
 ### `scripts/generate-embeddings.mjs`
 
 - Active build script used by `yarn embeddings` and `yarn build`.
+
+### `scripts/check-links.mjs`
+
+- Active script used by `yarn lint:links`.
+- Dependency-free internal-link and anchor validator for the `build/` output.
 
 ### `scripts/process-images.js`
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -45,6 +45,7 @@ Source of truth for local commands and script behavior in this repository.
 - Runs `node scripts/check-links.mjs`.
 - Walks the `build/` output and verifies every **internal** link resolves to a real file (handling pretty URLs → `index.html`), and checks `#fragment` links against the target page's `id`/`name` attributes.
 - External links (`http(s)://`, protocol-relative, `mailto:`, `tel:`, `data:`) are skipped on purpose — they are non-deterministic in CI.
+- Vercel-proxied hobby-project prefixes (read from `vercel.json` rewrites, e.g. `/PDF-A-go-go/`, `/pinment/`) are skipped too — they resolve in production via proxy but are absent from the local build. `<script>`/`<style>` bodies are stripped before scanning so JS template strings aren't treated as links.
 - Requires a build first (run `yarn eleventy` or `yarn build`). Exits non-zero if any internal link is broken.
 - Runs in CI after the build (currently non-blocking; see `.github/workflows/build-and-deploy.yml`).
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eleventy": "ELEVENTY_ENV=production eleventy --config=eleventy.js",
     "lint:css": "stylelint \"src/**/*.scss\" \"src/**/*.css\"",
     "lint:css:fix": "stylelint \"src/**/*.scss\" \"src/**/*.css\" --fix",
+    "lint:links": "node scripts/check-links.mjs",
     "embeddings": "node scripts/generate-embeddings.mjs",
     "build": "yarn clean && yarn sass && yarn eleventy && yarn embeddings && echo '🏋 Build completed'",
     "dev": "concurrently -k \"sass --load-path src/components --watch --poll src/components/vf-componenet-rollup/index.scss:build/css/styles.css\" \"ELEVENTY_ENV=development eleventy --serve --config=eleventy.js\"",

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -22,6 +22,22 @@ const BUILD_DIR = 'build';
 // Links we never resolve on disk.
 const EXTERNAL = /^(https?:|\/\/|mailto:|tel:|data:|javascript:|#)/i;
 
+// Path prefixes served by Vercel rewrites to external origins (hobby projects
+// proxied to GitHub Pages). They are valid in production but absent from the
+// local build, so resolving them on disk would be a false positive. Derived
+// from vercel.json rewrites, e.g. "/PDF-A-go-go/:path*" -> "/PDF-A-go-go/".
+function proxiedPrefixes() {
+  try {
+    const cfg = JSON.parse(readFileSync('vercel.json', 'utf-8'));
+    return (cfg.rewrites || [])
+      .map(r => (r.source || '').split(':')[0]) // strip ":path*"
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+const PROXIED = proxiedPrefixes();
+
 function findHtmlFiles(dir, files = []) {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
@@ -32,13 +48,19 @@ function findHtmlFiles(dir, files = []) {
 }
 
 // Extract href="..." and src="..." values (single or double quoted).
+// Strips <script>/<style> first so JS template strings (e.g. `${item.url}`)
+// aren't mistaken for links.
 function extractLinks(html) {
+  const cleaned = html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '');
   const links = [];
   const re = /(?:href|src)\s*=\s*("([^"]*)"|'([^']*)')/gi;
   let m;
-  while ((m = re.exec(html)) !== null) {
+  while ((m = re.exec(cleaned)) !== null) {
     const val = (m[2] ?? m[3] ?? '').trim();
-    if (val) links.push(val);
+    // Skip empty and unresolved template artifacts (e.g. `${...}`).
+    if (val && !val.includes('${')) links.push(val);
   }
   return links;
 }
@@ -105,6 +127,8 @@ function main() {
     const html = readFileSync(file, 'utf-8');
     for (const link of extractLinks(html)) {
       if (EXTERNAL.test(link)) continue;
+      // Skip Vercel-proxied hobby-project paths (valid in prod, not in build).
+      if (PROXIED.some(p => link === p || link.startsWith(p))) continue;
       checked++;
 
       const target = resolveTarget(link, file);

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,146 @@
+/**
+ * Validate internal links in the built site.
+ *
+ * Walks build/**\/*.html, extracts every href/src, and for each internal
+ * link checks that the target file exists in the build output. For internal
+ * links that include a #fragment, it also checks that an element with a
+ * matching id (or name) exists on the target page.
+ *
+ * External links (http/https/protocol-relative/mailto/tel/data) are skipped
+ * deliberately: they are non-deterministic in CI (rate limits, transient
+ * outages) and not something a build can guarantee. This check is about
+ * catching broken internal links and anchors, which a build *can* guarantee.
+ *
+ * Exits non-zero if any broken internal link is found. Run after `yarn eleventy`.
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
+import { join, relative, dirname, resolve, extname } from 'path';
+
+const BUILD_DIR = 'build';
+
+// Links we never resolve on disk.
+const EXTERNAL = /^(https?:|\/\/|mailto:|tel:|data:|javascript:|#)/i;
+
+function findHtmlFiles(dir, files = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) findHtmlFiles(full, files);
+    else if (entry.endsWith('.html')) files.push(full);
+  }
+  return files;
+}
+
+// Extract href="..." and src="..." values (single or double quoted).
+function extractLinks(html) {
+  const links = [];
+  const re = /(?:href|src)\s*=\s*("([^"]*)"|'([^']*)')/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const val = (m[2] ?? m[3] ?? '').trim();
+    if (val) links.push(val);
+  }
+  return links;
+}
+
+// Does the target HTML contain an element with id="frag" or name="frag"?
+function hasAnchor(html, frag) {
+  const f = frag.replace(/"/g, '');
+  const idRe = new RegExp(`\\b(?:id|name)\\s*=\\s*["']${escapeRegex(f)}["']`, 'i');
+  return idRe.test(html);
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Resolve a link to a candidate file path inside the build dir.
+// Returns the resolved absolute-ish path under BUILD_DIR, or null if it
+// escapes the build root.
+function resolveTarget(link, fromFile) {
+  let pathPart = link.split('#')[0].split('?')[0];
+  if (pathPart === '') return null; // pure fragment / query, handled by caller
+
+  let abs;
+  if (pathPart.startsWith('/')) {
+    abs = join(BUILD_DIR, pathPart);
+  } else {
+    abs = join(dirname(fromFile), pathPart);
+  }
+  abs = resolve(abs);
+  const root = resolve(BUILD_DIR);
+  if (abs !== root && !abs.startsWith(root + '/')) return null; // escapes build/
+  return abs;
+}
+
+// Given a resolved path, find the actual file on disk (handling pretty URLs).
+function locateFile(abs) {
+  if (existsSync(abs) && statSync(abs).isFile()) return abs;
+  // Directory or pretty URL → index.html
+  if (existsSync(abs) && statSync(abs).isDirectory()) {
+    const idx = join(abs, 'index.html');
+    if (existsSync(idx)) return idx;
+  }
+  // Extensionless pretty URL → try /index.html or .html
+  if (!extname(abs)) {
+    const idx = join(abs, 'index.html');
+    if (existsSync(idx)) return idx;
+    const html = abs + '.html';
+    if (existsSync(html)) return html;
+  }
+  return null;
+}
+
+function main() {
+  if (!existsSync(BUILD_DIR)) {
+    console.error(`Build directory "${BUILD_DIR}/" not found. Run \`yarn eleventy\` first.`);
+    process.exit(1);
+  }
+
+  const files = findHtmlFiles(BUILD_DIR);
+  const broken = [];
+  let checked = 0;
+
+  for (const file of files) {
+    const html = readFileSync(file, 'utf-8');
+    for (const link of extractLinks(html)) {
+      if (EXTERNAL.test(link)) continue;
+      checked++;
+
+      const target = resolveTarget(link, file);
+      if (target === null) {
+        broken.push({ file, link, reason: 'escapes build root or unresolvable' });
+        continue;
+      }
+
+      const located = locateFile(target);
+      if (!located) {
+        broken.push({ file, link, reason: 'target file not found' });
+        continue;
+      }
+
+      // Anchor check
+      const hash = link.includes('#') ? link.split('#')[1] : '';
+      if (hash && located.endsWith('.html')) {
+        const targetHtml = readFileSync(located, 'utf-8');
+        if (!hasAnchor(targetHtml, hash)) {
+          broken.push({ file, link, reason: `no element with id/name "${hash}"` });
+        }
+      }
+    }
+  }
+
+  console.log(`Checked ${checked} internal links across ${files.length} pages.`);
+
+  if (broken.length > 0) {
+    console.error(`\n❌ ${broken.length} broken internal link(s):\n`);
+    for (const b of broken) {
+      console.error(`  ${relative(BUILD_DIR, b.file)}\n    → ${b.link}  (${b.reason})`);
+    }
+    process.exit(1);
+  }
+
+  console.log('✅ No broken internal links.');
+}
+
+main();

--- a/scripts/generate-embeddings.mjs
+++ b/scripts/generate-embeddings.mjs
@@ -18,9 +18,14 @@
  *      for compatible models (look for ONNX exports with sentence-transformers)
  */
 
-import { pipeline } from '@huggingface/transformers';
+import { pipeline, env } from '@huggingface/transformers';
 import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'fs';
 import { join, relative } from 'path';
+
+// Cache downloaded model files in a stable, repo-local directory so CI can
+// restore them between builds (see actions/cache in build-and-deploy.yml).
+// Without this, the model re-downloads from HuggingFace on every build.
+env.cacheDir = '.cache/transformers';
 
 const BUILD_DIR = 'build';
 const OUTPUT_DIR = join(BUILD_DIR, 'semantic-search');

--- a/src/components/kh-ambience/_kh-ambience.scss
+++ b/src/components/kh-ambience/_kh-ambience.scss
@@ -30,12 +30,14 @@ $kh-ambience-sway-speed: 11s; // Blinds sway animation duration
 // Only animating sun-angle and opacity (slat dimensions remain constant)
 // Initial values match the starting state (top of page) in @keyframes kh-ambience-scroll-shift
 // https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timeline
+/* stylelint-disable-next-line at-rule-no-unknown, scss/at-rule-no-unknown */
 @property --ambience-sun-angle {
   syntax: '<angle>';
   initial-value: #{$kh-ambience-start-sun-angle};
   inherits: true;
 }
 
+/* stylelint-disable-next-line at-rule-no-unknown, scss/at-rule-no-unknown */
 @property --ambience-blinds-opacity {
   syntax: '<number>';
   initial-value: #{$kh-ambience-start-blinds-opacity};
@@ -90,6 +92,7 @@ body:has(#kh-css-toggle:checked) {
   }
 
   // Disable expensive SVG filter in Firefox; keep cheap blur only (Firefox-only at-rule)
+  /* stylelint-disable-next-line at-rule-no-unknown, scss/at-rule-no-unknown */
   @-moz-document url-prefix() {
     .kh-ambience-leaves {
       filter: blur(9px);

--- a/src/components/kh-font/README.md
+++ b/src/components/kh-font/README.md
@@ -1,16 +1,27 @@
 # Recursive webfont assets (self-hosted)
 
-https://github.com/arrowtype/recursive/tree/main/fonts
+Canonical setup and troubleshooting documentation lives in
+[`docs/FONTS.md`](../../../docs/FONTS.md).
 
-Place the variable WOFF2 file for Recursive here. Recommended:
+## Source of truth
 
-- Recursive_VF_1.085.woff2 (variable font with axes: wght, slnt, CASL, CRSV, MONO)
+- Upstream project: <https://github.com/arrowtype/recursive/tree/main/fonts>
+- This directory is the source path for local font assets:
+  `src/components/kh-font/`
 
-Download from the project releases or Google Fonts:
-- https://github.com/arrowtype/recursive/
+## Current active asset
 
-After placing the file, it will be copied to `build/kh-font/assets/` by Eleventy passthrough. Ensure CSS `@font-face` in `src/components/vf-componenet-rollup/index.scss` points to:
+- `Recursive_VF_1.085--subset-GF_latin_basic.woff2`
 
-```
-../kh-font/assets/Recursive_VF_1.085.woff2
+## Build + runtime paths
+
+Eleventy passthrough copies this directory to:
+
+- Output directory: `build/assets/kh-font/`
+
+The `@font-face` rule in
+`src/components/vf-componenet-rollup/index.scss` must reference:
+
+```css
+/assets/kh-font/Recursive_VF_1.085--subset-GF_latin_basic.woff2
 ```

--- a/src/components/vf-componenet-rollup/_semantic-search.scss
+++ b/src/components/vf-componenet-rollup/_semantic-search.scss
@@ -136,6 +136,7 @@
     appearance: none;
   }
 
+  /* stylelint-disable selector-pseudo-element-no-unknown */
   .kh-ask__message--status progress::-webkit-progress-bar {
     background: #e0ddd8;
     border-radius: 3px;
@@ -150,6 +151,7 @@
     background: var(--kh-color--blue);
     border-radius: 3px;
   }
+  /* stylelint-enable selector-pseudo-element-no-unknown */
 
   .kh-ask__results {
     display: flex;

--- a/src/components/vf-componenet-rollup/index.scss
+++ b/src/components/vf-componenet-rollup/index.scss
@@ -85,6 +85,7 @@ body:has(#kh-css-toggle:checked) {
     text-decoration-line: underline;
   }
 
+  /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
   input[type='search']::-webkit-search-cancel-button {
     appearance: none;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cpath d='M89.796 74.956a7 7 0 010-9.912L136.92 17.92a10.5 10.5 0 00-14.84-14.84L74.956 50.204a7 7 0 01-9.912 0L17.92 3.08A10.5 10.5 0 003.08 17.92l47.124 47.124a7 7 0 010 9.912L3.08 122.08a10.5 10.5 0 1014.84 14.84l47.124-47.124a7 7 0 019.912 0l47.124 47.124a10.5 10.5 0 0014.84-14.84z' fill='%2354585a'/%3E%3C/svg%3E");
@@ -212,13 +213,6 @@ body:has(#kh-css-toggle:checked) {
       position: absolute;
       top: 0;
       width: 100%;
-    }
-  }
-
-  @media (max-width: $kh-breakpoint--md-down) {
-    .kh-grid__col--span-1,
-    .kh-grid__col--span-2 {
-      grid-column: auto;
     }
   }
 
@@ -633,7 +627,7 @@ body:has(#kh-css-toggle:checked) {
     }
   }
   @media (max-width: $kh-breakpoint--lg-down) {
-    .kh-footer__links > *{
+    .kh-footer__links > * {
       margin-right: 1rem;
     }
   }
@@ -693,6 +687,7 @@ body:has(#kh-css-toggle:checked) {
     display: none;
   }
 
+  /* stylelint-disable-next-line media-feature-name-no-unknown */
   @media screen and (-ms-high-contrast: active) and (min-width: $kh-breakpoint--lg), screen and (-ms-high-contrast: none) and (min-width: $kh-breakpoint--lg) {
     .kh-footer {
       left: 50%;
@@ -924,7 +919,7 @@ body:has(#kh-css-toggle:checked) {
     --kh-stack-margin--custom: 0.25rem;
   }
 
-  .kh-form__item{
+  .kh-form__item {
     display: inline-flex;
     gap: 0.5rem;
   }

--- a/src/components/vf-componenet-rollup/normalize.scss
+++ b/src/components/vf-componenet-rollup/normalize.scss
@@ -59,6 +59,7 @@
   }
 
   // Remove the inner border and padding in Firefox.
+  /* stylelint-disable selector-pseudo-element-no-unknown, selector-pseudo-class-no-unknown */
   button::-moz-focus-inner,
   [type='button']::-moz-focus-inner,
   [type='reset']::-moz-focus-inner,
@@ -117,6 +118,7 @@
     -webkit-appearance: button; // 1
     font: inherit; // 2
   }
+  /* stylelint-enable selector-pseudo-element-no-unknown, selector-pseudo-class-no-unknown */
 
   // Interactive
   // ==========================================================================


### PR DESCRIPTION
## Summary
- Apply stylelint disable comments and cleanup for SCSS lint issues
- Skip proxied paths and script bodies in the internal link checker
- Cache the embeddings model and add internal link validation to CI
- Add docs for git hooks, font assets, and offline/service-worker behavior, with cross-links from README/CONTRIBUTING/docs

## Test plan
- [x] `yarn lint:css` passes
- [ ] CI build-and-deploy workflow passes