### PR TITLE
chore: backfill style guide and LaTeX workflows

### DIFF
--- a/docs/CITATION_WORKFLOW.md
+++ b/docs/CITATION_WORKFLOW.md
@@ -14,15 +14,18 @@ allaboutken.com is the canonical source for the writing, but posts here have no 
 
 ## Where the LaTeX source lives
 
-`latex/` at the repo root, one subdirectory per piece being adapted (e.g. `latex/cadi-framework/`). See `latex/README.md` for build instructions (Overleaf or a local TeX install — no LaTeX toolchain is assumed to exist in this repo's normal dev environment).
+`latex/` at the repo root, one subdirectory per piece being adapted (e.g. `latex/cadi-framework/`). See [`latex/README.md`](../latex/README.md) for shared build context and:
+
+- [`latex/poc-minimal/README.md`](../latex/poc-minimal/README.md) for the initial toolchain check artifact
+- [`latex/cadi-framework/README.md`](../latex/cadi-framework/README.md) for pilot-specific structure, build, and pre-deposit checks
 
 Each subdirectory is a standalone paper adaptation of a published post: restructured with an abstract and paper-style sections, not a raw copy of the site markdown. The post itself stays the canonical, human-readable version; the LaTeX version exists to produce a citable PDF.
 
 ## Workflow
 
 1. **Pick a post.** Prioritize pieces with real original framing and reference lists — they read as papers with the least rework. The CADI framework post is the pilot.
-2. **Adapt to LaTeX** in `latex/<piece-name>/main.tex`. Keep the author block consistent: name, "Independent Researcher," ORCID link. [Jenni.ai](https://jenni.ai/) is an optional aid for this step on future pieces — academic-style rewriting and citation lookup — for posts that need more restructuring than a straight condense. Not used for the CADI pilot, and not a substitute for any other step here (no LaTeX compiling, no Zenodo/ORCID integration).
-3. **Build the PDF** (Overleaf or local `pdflatex`/`latexmk`). Check it renders cleanly before depositing.
+2. **Adapt to LaTeX** in `latex/<piece-name>/main.tex` (or the artifact's primary `.tex` file). Keep the author block consistent: name, "Independent Researcher," ORCID link. [Jenni.ai](https://jenni.ai/) is an optional aid for this step on future pieces — academic-style rewriting and citation lookup — for posts that need more restructuring than a straight condense. Not used for the CADI pilot, and not a substitute for any other step here (no LaTeX compiling, no Zenodo/ORCID integration).
+3. **Build the PDF** (Overleaf or local `pdflatex`/`latexmk`) using the artifact-specific README: run `pdflatex minimal.tex` in `latex/poc-minimal/` or `pdflatex main.tex` in `latex/cadi-framework/`. Check the resulting `minimal.pdf` or `main.pdf` renders cleanly before depositing.
 4. **Deposit on Zenodo** under user `khawkins98`:
    - Upload the PDF (and optionally the `.tex` source).
    - Link ORCID `0009-0009-6728-2237` as the author identifier during submission.
@@ -43,7 +46,7 @@ Everything past LaTeX-source-in-this-repo (the actual Zenodo upload, ORCID linki
 
 ## Compiling: staying manual for now
 
-Building `.tex` -> PDF is a manual, occasional step (Overleaf, or local `pdflatex`/`latexmk` per `latex/README.md`), not wired into `yarn build`. At the current volume — a couple of proof-of-concept files, one pilot paper — a compile pipeline would be more machinery than the problem needs.
+Building `.tex` -> PDF is a manual, occasional step (Overleaf, or local `pdflatex`/`latexmk` per `latex/README.md` and each artifact README), not wired into `yarn build`. At the current volume — a couple of proof-of-concept files, one pilot paper — a compile pipeline would be more machinery than the problem needs.
 
 **If this scales** (papers become a recurring habit rather than an occasional pilot), the realistic next step is [Tectonic](https://tectonic-typesetting.github.io/): a single self-contained binary, drop-in `pdflatex` replacement, fetches missing packages automatically, no TeX Live install required. At that point it's a small addition — `brew install tectonic` plus a `yarn compile:latex` script that shells out to it, same pattern this repo already uses for Sass/Eleventy — and could even run in CI to produce PDFs as build artifacts.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Use this page as the entry point for repository documentation. It maps each doc 
 | [`ROLE_TEMPLATE.md`](ROLE_TEMPLATE.md) | Template for defining new reviewer roles | Maintainers adding roles | You are introducing a new role profile |
 | [`../worker/README.md`](../worker/README.md) | Feedback worker routes, local dev, and deploy commands | Maintainer/operators | You are operating or debugging `feedback.allaboutken.com` |
 | [`../src/site/style-guide/editorial.njk`](../src/site/style-guide/editorial.njk) | Canonical voice/tone/style guidance | Authors and editors | You need writing standards while drafting or editing |
+| [`STYLE_GUIDE_SURFACES.md`](STYLE_GUIDE_SURFACES.md) | Map of style-guide pages (`index.njk`, `components.njk`, `editorial.njk`), ownership, and usage boundaries | Contributors touching templates, CSS, or editorial standards | You need to choose the right style-guide source of truth, especially for component implementation references |
 | [`FRONTMATTER.md`](FRONTMATTER.md) | Reference for every YAML frontmatter field used across post, page, and digest templates | Authors, editors, and contributors adding posts | You need to know what a field does, which templates use it, and whether it is required |
 | [`ELEVENTY_CONFIG.md`](ELEVENTY_CONFIG.md) | Reference for all plugins, filters, shortcodes, collections, and config options in `eleventy.js` | Contributors modifying build config or templates | You are adding a filter, shortcode, or collection, or need to understand how the build pipeline works |
 | [`DATA_FILES.md`](DATA_FILES.md) | Schema and template usage for `siteConfig.json` and `garage.json` | Contributors editing site-wide config or the garage project listing | You are adding a garage project, updating site metadata, or tracing where a global value comes from |
@@ -34,6 +35,7 @@ Use this page as the entry point for repository documentation. It maps each doc 
 
 - **New contributor:** `../README.md` -> `../CONTRIBUTING.md` -> `GIT_HOOKS.md` -> `SCRIPTS.md`
 - **Template work:** `TEMPLATES.md` -> `FRONTMATTER.md` -> `ELEVENTY_CONFIG.md`
+- **Style-guide alignment:** `STYLE_GUIDE_SURFACES.md` -> `../src/site/style-guide/components.njk` -> `../src/site/style-guide/editorial.njk`
 - **Component work:** `COMPONENTS.md` -> `CSS_ARCHITECTURE.md` -> `FONTS.md` -> `ELEVENTY_CONFIG.md`
 - **Local setup/debugging:** `DEVELOPMENT_SETUP.md` -> `SCRIPTS.md`
 - **Offline behavior:** `OFFLINE_SERVICE_WORKER.md` -> `ELEVENTY_CONFIG.md` -> `DEVELOPMENT_SETUP.md`

--- a/docs/STYLE_GUIDE_SURFACES.md
+++ b/docs/STYLE_GUIDE_SURFACES.md
@@ -1,0 +1,41 @@
+# Style guide surfaces
+
+This reference explains the three public style-guide pages in `src/site/style-guide/`, who owns them, and when contributors should use each one.
+
+## Quick map
+
+| Surface | Source file | Public URL | Primary owner | Use it when |
+| --- | --- | --- | --- | --- |
+| Style guide landing page | `src/site/style-guide/index.njk` | `/style-guide/` | Maintainer/editorial lead | You need the entry point that routes contributors to visual vs editorial guidance |
+| Component reference | `src/site/style-guide/components.njk` | `/style-guide/components/` | Frontend/design-system maintainers | You are implementing or reviewing UI markup/classes and need live visual + class-level examples |
+| Editorial style guide | `src/site/style-guide/editorial.njk` | `/style-guide/editorial/` | Editorial owner (Ken) | You are drafting or editing content and need voice, structure, frontmatter, and reasoning standards |
+
+## What each page is for
+
+### `index.njk` (navigator)
+
+- Keeps the style-guide area discoverable from a single URL.
+- Should stay brief; it is a routing page, not a duplicate of detailed guidance.
+- Update this page when adding/removing style-guide subpages or changing naming.
+
+### `components.njk` (visual and implementation reference)
+
+This is the under-documented surface this backfill addresses most directly. It is the canonical implementation reference for visual patterns.
+
+- Documents live demos and markup for tokens, typography, buttons, note boxes, layout primitives, utility classes, accessibility helpers, and feedback/search UI patterns.
+- Use this page as the first check when deciding whether an existing class/pattern already exists before adding new CSS.
+- Treat examples here as behavioral contracts for reusable UI patterns; when refactoring styles/components, confirm this page still renders correctly.
+- Cross-reference:
+  - [`TEMPLATES.md`](TEMPLATES.md) for where markup is assembled.
+  - [`CSS_ARCHITECTURE.md`](CSS_ARCHITECTURE.md) for Sass organization and toggle constraints.
+
+### `editorial.njk` (voice and content system)
+
+- Defines tone, content-type expectations, frontmatter expectations, and writing quality checks.
+- Pair this with `components.njk` when content guidance references a visual pattern (for example note boxes, margin notes, and code+demo blocks).
+
+## Contributor workflow
+
+1. Start with `/style-guide/` when orienting.
+2. For template/CSS/UI work, read `/style-guide/components/` first, then `docs/TEMPLATES.md` and `docs/CSS_ARCHITECTURE.md`.
+3. For writing/review work, read `/style-guide/editorial/` first, then `docs/PUBLISHING_WORKFLOW.md`.

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -76,6 +76,14 @@ Paragraph in markdown.
 
 For field semantics, use [`FRONTMATTER.md`](FRONTMATTER.md). For filters/shortcodes/collections, use [`ELEVENTY_CONFIG.md`](ELEVENTY_CONFIG.md). For global JSON data files, use [`DATA_FILES.md`](DATA_FILES.md).
 
+## Mapping templates to style-guide pages
+
+When template work changes rendered output, check style-guide surfaces in this order:
+
+1. [`../src/site/style-guide/components.njk`](../src/site/style-guide/components.njk) for visual patterns, class names, and live component examples.
+2. [`../src/site/style-guide/editorial.njk`](../src/site/style-guide/editorial.njk) for voice/structure rules and when to use specific content patterns.
+3. [`STYLE_GUIDE_SURFACES.md`](STYLE_GUIDE_SURFACES.md) for ownership and boundaries between the style-guide pages.
+
 ## Modifying existing layouts safely
 
 1. Update the layout/partial in `src/site/_includes/`.

--- a/latex/README.md
+++ b/latex/README.md
@@ -1,21 +1,26 @@
 # latex/
 
-Source for pieces from allaboutken.com being adapted into citable, LaTeX-formatted documents for deposit on [Zenodo](https://zenodo.org) (user `khawkins98`), cross-linked to [ORCID 0009-0009-6728-2237](https://orcid.org/0009-0009-6728-2237). Background and workflow: `docs/CITATION_WORKFLOW.md`.
+Source for pieces from allaboutken.com being adapted into citable, LaTeX-formatted documents for deposit on [Zenodo](https://zenodo.org) (user `khawkins98`), cross-linked to [ORCID 0009-0009-6728-2237](https://orcid.org/0009-0009-6728-2237). See the shared [citation and DOI workflow](../docs/CITATION_WORKFLOW.md) for the end-to-end process.
 
 ## Contents
 
-- `poc-minimal/` — smallest possible document to verify the LaTeX toolchain (Overleaf or a local install) before investing time in a full paper. Build this first.
-- `cadi-framework/` — the pilot: an adaptation of the [CADI framework post](https://www.allaboutken.com/posts/20260609-iterative-pattern-framework/) into paper form, structured for Zenodo deposit.
+- [`poc-minimal/`](poc-minimal/README.md) — smallest possible document to verify the LaTeX toolchain (Overleaf or a local install) before investing time in a full paper. Build this first.
+- [`cadi-framework/`](cadi-framework/README.md) — the pilot: an adaptation of the [CADI framework post](https://www.allaboutken.com/posts/20260609-iterative-pattern-framework/) into paper form, structured for Zenodo deposit.
 
 ## Building
 
 No LaTeX distribution is assumed to be installed in this repo's dev environment. Two options:
 
 1. **Overleaf** (recommended, zero local setup): create a new project, upload the `.tex` file, compile.
-2. **Local**: install a TeX distribution (e.g. MacTeX, or `brew install --cask basictex` for a lighter footprint), then from the relevant subdirectory:
+2. **Local**: install a TeX distribution (e.g. MacTeX, or `brew install --cask basictex` for a lighter footprint), then from the relevant subdirectory (use that artifact's main `.tex` filename, such as `minimal.tex` or `main.tex`):
    ```bash
-   pdflatex main.tex
+   pdflatex <artifact-file>.tex
    ```
    Run twice if references/citations don't resolve on the first pass.
 
 These files are not wired into the Eleventy build — they're a separate, manually-built artifact track for the citation workflow.
+
+## Guidance split
+
+- [`docs/CITATION_WORKFLOW.md`](../docs/CITATION_WORKFLOW.md) covers the end-to-end process (selection, deposit, DOI cross-linking).
+- The [`poc-minimal` README](poc-minimal/README.md) and [`cadi-framework` README](cadi-framework/README.md) cover document-specific sources, compile details, expected outputs, metadata checks, and readiness criteria.

--- a/latex/cadi-framework/README.md
+++ b/latex/cadi-framework/README.md
@@ -1,0 +1,74 @@
+# `cadi-framework`
+
+Paper-form adaptation of the CADI framework post, prepared for Zenodo deposit and DOI minting.
+
+## Purpose
+
+`main.tex` is the pilot artifact for the citation workflow described in `../../docs/CITATION_WORKFLOW.md`. It restructures the source post into an abstracted, sectioned paper format that can be deposited as a citable PDF.
+
+Source post:
+
+- https://www.allaboutken.com/posts/20260609-iterative-pattern-framework/
+
+## Inputs and outputs
+
+- **Input source:** `main.tex`
+- **Output artifact:** `main.pdf` (local build) or Overleaf-generated PDF download
+- **Expected usage:** Zenodo pilot deposit after the checks below pass
+
+## Document structure
+
+`main.tex` is organized as:
+
+1. Metadata block (`\title`, `\author`, ORCID link, `\date`)
+2. Abstract
+3. Main argument sections (problem, framework, case study, limits, related work, conclusion)
+4. Manual references list
+
+## Build commands
+
+### Overleaf
+
+1. Create a new blank project.
+2. Upload `main.tex`.
+3. Compile with `main.tex` as the main file.
+
+### Local
+
+From this directory:
+
+```bash
+pdflatex main.tex
+```
+
+Or with `latexmk`:
+
+```bash
+latexmk -pdf main.tex
+```
+
+Run a second pass if cross-references or link targets are unresolved.
+
+## Metadata consistency requirements
+
+Before deposit, keep metadata aligned across:
+
+- `main.tex`
+- Zenodo submission form
+- canonical post metadata on allaboutken.com (title/date context)
+
+Check specifically:
+
+1. Title text matches the intended deposited work.
+2. Author is `Ken Hawkins` with `Independent Researcher`.
+3. ORCID is `0009-0009-6728-2237` and linked correctly.
+4. Publication date in Zenodo matches the intended citation date for this artifact.
+
+## Pre-deposit checklist (Zenodo)
+
+1. `main.pdf` compiles cleanly and opens without rendering issues.
+2. Title/author/ORCID/date are consistent with the metadata requirements above.
+3. References and links are present and readable.
+4. Upload PDF to Zenodo (optionally include source `.tex`).
+5. Confirm ORCID linkage during submission.
+6. After DOI is minted, back-link the DOI into the source post and profile surfaces per `../../docs/CITATION_WORKFLOW.md`.

--- a/latex/poc-minimal/README.md
+++ b/latex/poc-minimal/README.md
@@ -1,0 +1,50 @@
+# `poc-minimal`
+
+Minimal LaTeX proof-of-concept used to verify the citation toolchain before working on a full paper adaptation.
+
+## Purpose
+
+This artifact checks that the core Zenodo-bound PDF pipeline works end to end:
+
+- article-class LaTeX document compiles cleanly
+- author block includes affiliation and ORCID link
+- title, abstract, sections, and references render as expected
+
+If this file compiles and opens cleanly, the same toolchain is considered ready for `../cadi-framework/main.tex`.
+
+## Inputs and outputs
+
+- **Input source:** `minimal.tex`
+- **Output artifact:** `minimal.pdf` (local build) or Overleaf-generated PDF download
+- **Expected usage:** toolchain check only, not for deposit
+
+## Build commands
+
+### Overleaf
+
+1. Create a new blank project.
+2. Upload `minimal.tex`.
+3. Compile with `minimal.tex` as the main file.
+
+### Local
+
+From this directory:
+
+```bash
+pdflatex minimal.tex
+```
+
+Or with `latexmk`:
+
+```bash
+latexmk -pdf minimal.tex
+```
+
+## Success criteria
+
+Treat the toolchain check as successful when all of the following are true:
+
+1. Compilation finishes without fatal errors.
+2. `minimal.pdf` opens and renders the title, `Ken Hawkins`, `Independent Researcher`, ORCID `0009-0009-6728-2237`, abstract, and section headings from `minimal.tex`.
+3. Hyperlinks are clickable in the generated PDF.
+4. Output is suitable to proceed to the full pilot document in `../cadi-framework/`.


### PR DESCRIPTION
## Summary

- map the three style-guide surfaces, ownership boundaries, and contributor read paths
- document template review order against component and editorial guidance
- add artifact-specific LaTeX build, metadata, output, and readiness instructions
- align the citation workflow with the real minimal.tex and main.tex entry points

## Test plan

- git diff --check
- repository-relative Markdown link check: 43 links across 7 scoped files
- yarn build (passes; one pre-existing remote EBI image returns 404 but Eleventy completes)
- yarn lint:links (reports 14 pre-existing broken generated-site links outside this documentation scope)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:/Users/khawkins/Documents/git/allaboutken-11ty
task-type: docs-backfill
task-title: Documentation Backfiller
provider: codex
score: 0.8
cost-tier: Low (10-50k)
branch: chore/lint-fix-iteration3-js
iterations: 1
duration: 13m54s
run-started: 2026-07-16T02:00:02+02:00
nightshift:metadata -->
