### PR TITLE
chore: apply JavaScript formatting

### DIFF
--- a/eleventy.js
+++ b/eleventy.js
@@ -18,31 +18,31 @@
  */
 
 const { DateTime } = require('luxon');
-const Path         = require('path');
+const Path = require('path');
 const { execSync, exec } = require('child_process');
-const { eleventyImageTransformPlugin } = require("@11ty/eleventy-img");
+const { eleventyImageTransformPlugin } = require('@11ty/eleventy-img');
 // const UpgradeHelper = require("@11ty/eleventy-upgrade-help");
 
-module.exports = function(config) {
+module.exports = function (config) {
   const isDev = process.env.ELEVENTY_ENV === 'development';
   // Transform <img>/<picture> in HTML to responsive images at build time
   config.addPlugin(eleventyImageTransformPlugin, {
-    outputDir: "./build/img/",
-    urlPath: "/img/",
+    outputDir: './build/img/',
+    urlPath: '/img/',
     widths: [320, 600, 900, 1280],
-    formats: ["avif", "webp", "jpeg", "gif"],
+    formats: ['avif', 'webp', 'jpeg', 'gif'],
     transformOnRequest: isDev,
     // Do not fail the entire build on a single image error (e.g., 404 remote)
     failOnError: false,
     // Preserve animation for GIF/WEBP when resizing/encoding
     sharpOptions: {
-      animated: true
+      animated: true,
     },
     sharpWebpOptions: {
-      animated: true
+      animated: true,
     },
     sharpGifOptions: {
-      reoptimise: true
+      reoptimise: true,
     },
     // Deterministic file names: <dir-token>-<base-name>-<width>.<format>
     filenameFormat: function filenameFormat(id, src, width, format) {
@@ -78,11 +78,11 @@ module.exports = function(config) {
     },
     htmlOptions: {
       img: {
-        decoding: "async",
-        loading: "lazy",
-        sizes: "100vw"
-      }
-    }
+        decoding: 'async',
+        loading: 'lazy',
+        sizes: '100vw',
+      },
+    },
   });
   config.setServerOptions({
     showVersion: true,
@@ -92,7 +92,7 @@ module.exports = function(config) {
     domDiff: true,
 
     watch: [
-      "build/**/*.css" // watch compiled CSS from Sass for instant reloads
+      'build/**/*.css', // watch compiled CSS from Sass for instant reloads
     ],
 
     // Show local network IP addresses for device testing
@@ -105,12 +105,12 @@ module.exports = function(config) {
     },
 
     // Change the default file encoding for reading/serving files
-    encoding: "utf-8",
+    encoding: 'utf-8',
   });
 
   // Fix any image src paths that were rewritten to input filesystem paths.
   // Ensures URLs point to passthrough-copied /images/ in output.
-  config.addTransform("fixImageSrcToAbsolute", (content, outputPath) => {
+  config.addTransform('fixImageSrcToAbsolute', (content, outputPath) => {
     try {
       if (typeof content !== 'string') return content;
       if (!outputPath || !outputPath.endsWith('.html')) return content;
@@ -125,70 +125,74 @@ module.exports = function(config) {
   // -----
 
   // Add any utility filters
-  config.addFilter("dateDisplay", (dateObj, format = "d LLL y") => {
+  config.addFilter('dateDisplay', (dateObj, format = 'd LLL y') => {
     return DateTime.fromJSDate(dateObj, {
-      zone: "utc"
+      zone: 'utc',
     }).toFormat(format);
   });
 
   // Return the first N items of an array (more specific name to avoid collisions)
-  config.addFilter("limitItems", (array, n) => {
+  config.addFilter('limitItems', (array, n) => {
     if (!Array.isArray(array)) return array;
     if (typeof n !== 'number') return array;
     return n < 0 ? array.slice(n) : array.slice(0, n);
   });
 
   // Ensure trailing slash on URLs for canonical IDs
-  config.addFilter("ensureTrailingSlash", (value) => {
+  config.addFilter('ensureTrailingSlash', (value) => {
     const v = String(value || '');
     if (!v) return v;
     return v.endsWith('/') ? v : v + '/';
   });
-  config.addFilter("rssDate", (dateObj) => {
-    return DateTime.fromJSDate(dateObj, { zone: "utc" }).toISO();
+  config.addFilter('rssDate', (dateObj) => {
+    return DateTime.fromJSDate(dateObj, { zone: 'utc' }).toISO();
   });
-  config.addFilter("rssLastUpdatedDate", (posts) => {
+  config.addFilter('rssLastUpdatedDate', (posts) => {
     if (!Array.isArray(posts) || posts.length === 0) return DateTime.now().toISO();
     const latest = posts.reduce((a, b) => (a.date > b.date ? a : b));
-    return DateTime.fromJSDate(latest.date, { zone: "utc" }).toISO();
+    return DateTime.fromJSDate(latest.date, { zone: 'utc' }).toISO();
   });
   // Convert double hyphens to em dashes for nicer typography
-  config.addFilter("emdash", (value) => {
+  config.addFilter('emdash', (value) => {
     const v = String(value || '');
     return v.replace(/--/g, '—');
   });
-  config.addFilter("htmlToAbsoluteUrls", (content, siteBaseUrl) => {
+  config.addFilter('htmlToAbsoluteUrls', (content, siteBaseUrl) => {
     const base = (siteBaseUrl || '').replace(/\/$/, '');
     const html = content || '';
-    return html
-      // href attributes
-      .replace(/href="\/(?!\/)/g, `href="${base}/`)
-      // src attributes
-      .replace(/src="\/(?!\/)/g, `src="${base}/`)
-      // srcset attributes (handles comma-separated URLs)
-      .replace(/srcset="([^"]*)"/g, (m, val) => {
-        const updated = (val || '').replace(/\s+\/(?!\/)/g, ` ${base}/`).replace(/^\/(?!\/)/, `${base}/`);
-        return `srcset="${updated}"`;
-      });
+    return (
+      html
+        // href attributes
+        .replace(/href="\/(?!\/)/g, `href="${base}/`)
+        // src attributes
+        .replace(/src="\/(?!\/)/g, `src="${base}/`)
+        // srcset attributes (handles comma-separated URLs)
+        .replace(/srcset="([^"]*)"/g, (m, val) => {
+          const updated = (val || '').replace(/\s+\/(?!\/)/g, ` ${base}/`).replace(/^\/(?!\/)/, `${base}/`);
+          return `srcset="${updated}"`;
+        })
+    );
   });
 
   // Strip unsafe elements/attributes from feed content
-  config.addFilter("sanitizeFeedHtml", (content) => {
+  config.addFilter('sanitizeFeedHtml', (content) => {
     const html = String(content || '');
-    return html
-      // remove script/style/link/iframe blocks
-      .replace(/<script[\s\S]*?<\/script>/gi, '')
-      .replace(/<style[\s\S]*?<\/style>/gi, '')
-      .replace(/<link[^>]*>/gi, '')
-      .replace(/<iframe[\s\S]*?<\/iframe>/gi, '')
-      // drop inline style attributes
-      .replace(/\sstyle="[^"]*"/gi, '')
-      // drop inline event handlers (on*)
-      .replace(/\son[a-z]+="[^"]*"/gi, '');
+    return (
+      html
+        // remove script/style/link/iframe blocks
+        .replace(/<script[\s\S]*?<\/script>/gi, '')
+        .replace(/<style[\s\S]*?<\/style>/gi, '')
+        .replace(/<link[^>]*>/gi, '')
+        .replace(/<iframe[\s\S]*?<\/iframe>/gi, '')
+        // drop inline style attributes
+        .replace(/\sstyle="[^"]*"/gi, '')
+        // drop inline event handlers (on*)
+        .replace(/\son[a-z]+="[^"]*"/gi, '')
+    );
   });
 
   // Compute plain-text word count from HTML content
-  config.addFilter("wordCount", (content) => {
+  config.addFilter('wordCount', (content) => {
     try {
       const html = String(content || '');
       const cleaned = html
@@ -208,7 +212,7 @@ module.exports = function(config) {
   });
 
   // Format a number with locale separators (e.g., 1,234)
-  config.addFilter("formatNumber", (value, locale = 'en-US') => {
+  config.addFilter('formatNumber', (value, locale = 'en-US') => {
     try {
       const n = Number(value);
       if (!isFinite(n)) return String(value ?? '');
@@ -248,44 +252,45 @@ module.exports = function(config) {
     });
   };
 
-  const md = markdownIt({ html: true, linkify: true }).use(markdownItAnchor, {
-    // Add ids to all heading levels so we can deep-link
-    level: [1, 2, 3, 4, 5, 6],
-    // Create clean ASCII slugs: remove punctuation/specials, collapse spaces to '-'
-    slugify: (s) => (
-      (s || '')
-        .toString()
-        .toLowerCase()
-        .normalize('NFKD')
-        .replace(/[\u0300-\u036f]/g, '') // strip combining marks
-        .replace(/&amp;/g, 'and')
-        .replace(/[^a-z0-9\s-]/g, '') // drop punctuation and specials (e.g. ?!@():’–)
-        .replace(/[\s_-]+/g, '-')
-        .replace(/^-+|-+$/g, '')
-    ),
+  const md = markdownIt({ html: true, linkify: true })
+    .use(markdownItAnchor, {
+      // Add ids to all heading levels so we can deep-link
+      level: [1, 2, 3, 4, 5, 6],
+      // Create clean ASCII slugs: remove punctuation/specials, collapse spaces to '-'
+      slugify: (s) =>
+        (s || '')
+          .toString()
+          .toLowerCase()
+          .normalize('NFKD')
+          .replace(/[\u0300-\u036f]/g, '') // strip combining marks
+          .replace(/&amp;/g, 'and')
+          .replace(/[^a-z0-9\s-]/g, '') // drop punctuation and specials (e.g. ?!@():’–)
+          .replace(/[\s_-]+/g, '-')
+          .replace(/^-+|-+$/g, ''),
 
-    // Append a discrete '#' permalink link to the end of the heading content
-    permalink: (slug, opts, state, index) => {
-      try {
-        const inlineToken = state.tokens[index + 1];
-        if (!inlineToken || !Array.isArray(inlineToken.children)) return;
-        // Create a small '#' anchor link that is the only clickable element
-        const linkOpen = new state.Token('link_open', 'a', 1);
-        linkOpen.attrs = [
-          ['href', `#${slug}`],
-          ['class', 'kh-anchor'],
-          ['aria-label', 'Permalink to this heading']
-        ];
-        const textToken = new state.Token('text', '', 0);
-        textToken.content = '#';
-        const linkClose = new state.Token('link_close', 'a', -1);
+      // Append a discrete '#' permalink link to the end of the heading content
+      permalink: (slug, opts, state, index) => {
+        try {
+          const inlineToken = state.tokens[index + 1];
+          if (!inlineToken || !Array.isArray(inlineToken.children)) return;
+          // Create a small '#' anchor link that is the only clickable element
+          const linkOpen = new state.Token('link_open', 'a', 1);
+          linkOpen.attrs = [
+            ['href', `#${slug}`],
+            ['class', 'kh-anchor'],
+            ['aria-label', 'Permalink to this heading'],
+          ];
+          const textToken = new state.Token('text', '', 0);
+          textToken.content = '#';
+          const linkClose = new state.Token('link_close', 'a', -1);
 
-        inlineToken.children.push(linkOpen, textToken, linkClose);
-      } catch (e) {
-        // no-op
-      }
-    }
-  }).use(emdashPlugin);
+          inlineToken.children.push(linkOpen, textToken, linkClose);
+        } catch (e) {
+          // no-op
+        }
+      },
+    })
+    .use(emdashPlugin);
 
   // Use for Eleventy's markdown engine (for .md files and markdown in templates)
   config.setLibrary('md', md);
@@ -300,26 +305,14 @@ module.exports = function(config) {
   // {% endcodeAndDemo %}
   config.addPairedShortcode('codeAndDemo', (content, lang = 'html') => {
     const snippet = String(content || '');
-    const escapeHtml = (s) => (
-      String(s)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-    );
+    const escapeHtml = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     const escaped = escapeHtml(snippet);
-    return [
-      '<div class="kh-demo" data-pagefind-ignore>',
-      `<pre><code class="language-${lang}">${escaped}</code></pre>`,
-      '<div class="kh-demo__live">',
-      snippet,
-      '</div>',
-      '</div>'
-    ].join('');
+    return ['<div class="kh-demo" data-pagefind-ignore>', `<pre><code class="language-${lang}">${escaped}</code></pre>`, '<div class="kh-demo__live">', snippet, '</div>', '</div>'].join('');
   });
 
   // Shortcode to generate Eleventy screenshot service URL for dynamic OG images
   // Usage: {% ogImageUrl %}
-  config.addShortcode('ogImageUrl', function() {
+  config.addShortcode('ogImageUrl', function () {
     // Build the social card URL for this page
     const socialCardUrl = `https://www.allaboutken.com/social${this.page.url}`;
     // URI encode the URL for the screenshot service
@@ -373,22 +366,22 @@ module.exports = function(config) {
   // });
 
   // copy js files
-  config.addPassthroughCopy("./src/site/**/*.js");
+  config.addPassthroughCopy('./src/site/**/*.js');
   // pass through favicon assets
-  config.addPassthroughCopy({ "./src/components/ken-favicon/assets": "assets/ken-favicon/assets" });
+  config.addPassthroughCopy({ './src/components/ken-favicon/assets': 'assets/ken-favicon/assets' });
 
   // pass some assets right through
-  config.addPassthroughCopy("./src/site/images");
+  config.addPassthroughCopy('./src/site/images');
 
   // Copy local Recursive font assets to build
-  config.addPassthroughCopy({ "./src/components/kh-font": "assets/kh-font" });
+  config.addPassthroughCopy({ './src/components/kh-font': 'assets/kh-font' });
   // mostly needed for redirecting from old drupal urls
-  config.addPassthroughCopy("./src/site/**/*.html");
+  config.addPassthroughCopy('./src/site/**/*.html');
   // downloadable text resources (starter kits, templates)
-  config.addPassthroughCopy("./src/site/**/*.txt");
+  config.addPassthroughCopy('./src/site/**/*.txt');
 
   // Watch source images for changes
-  config.addWatchTarget("./src/site/images");
+  config.addWatchTarget('./src/site/images');
 
   // Post-build: generate Pagefind search index
   let pagefindChild = null;
@@ -424,7 +417,8 @@ module.exports = function(config) {
 
   config.addCollection('impactStories', (collectionApi) => {
     try {
-      return collectionApi.getAll()
+      return collectionApi
+        .getAll()
         .filter((item) => getTagArray(item).includes('impact-stories'))
         .sort((a, b) => b.date - a.date);
     } catch (e) {
@@ -434,12 +428,11 @@ module.exports = function(config) {
 
   config.addCollection('blogPosts', (collectionApi) => {
     try {
-      return collectionApi.getAll()
+      return collectionApi
+        .getAll()
         .filter((item) => {
           const tags = getTagArray(item);
-          return tags.includes('posts')
-            && !tags.includes('case-studies')
-            && !tags.includes('impact-stories');
+          return tags.includes('posts') && !tags.includes('case-studies') && !tags.includes('impact-stories');
         })
         .sort((a, b) => b.date - a.date);
     } catch (e) {
@@ -449,7 +442,8 @@ module.exports = function(config) {
 
   config.addCollection('allContent', (collectionApi) => {
     try {
-      return collectionApi.getAll()
+      return collectionApi
+        .getAll()
         .filter((item) => {
           const tags = getTagArray(item);
           return tags.includes('posts') || tags.includes('digesting');
@@ -465,17 +459,14 @@ module.exports = function(config) {
   // If you have other `addPlugin` calls, it’s important that UpgradeHelper is added last.
   return {
     dir: {
-      input: "src/site",
-      output: "build",
-      data: "_data",
-      includes: "_includes"
+      input: 'src/site',
+      output: 'build',
+      data: '_data',
+      includes: '_includes',
     },
-    templateFormats : [
-      "njk", "md",
-      "css", "js"
-    ],
-    htmlTemplateEngine : ["njk", "md"],
-    markdownTemplateEngine : "njk",
+    templateFormats: ['njk', 'md', 'css', 'js'],
+    htmlTemplateEngine: ['njk', 'md'],
+    markdownTemplateEngine: 'njk',
     passthroughFileCopy: true,
     // pathPrefix: "/vf-eleventy/" // if your site is deployed to a sub-url, otherwise comment out
   };

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -30,7 +30,7 @@ function proxiedPrefixes() {
   try {
     const cfg = JSON.parse(readFileSync('vercel.json', 'utf-8'));
     return (cfg.rewrites || [])
-      .map(r => (r.source || '').split(':')[0]) // strip ":path*"
+      .map((r) => (r.source || '').split(':')[0]) // strip ":path*"
       .filter(Boolean);
   } catch {
     return [];
@@ -51,9 +51,7 @@ function findHtmlFiles(dir, files = []) {
 // Strips <script>/<style> first so JS template strings (e.g. `${item.url}`)
 // aren't mistaken for links.
 function extractLinks(html) {
-  const cleaned = html
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '');
+  const cleaned = html.replace(/<script[\s\S]*?<\/script>/gi, '').replace(/<style[\s\S]*?<\/style>/gi, '');
   const links = [];
   const re = /(?:href|src)\s*=\s*("([^"]*)"|'([^']*)')/gi;
   let m;
@@ -128,7 +126,7 @@ function main() {
     for (const link of extractLinks(html)) {
       if (EXTERNAL.test(link)) continue;
       // Skip Vercel-proxied hobby-project paths (valid in prod, not in build).
-      if (PROXIED.some(p => link === p || link.startsWith(p))) continue;
+      if (PROXIED.some((p) => link === p || link.startsWith(p))) continue;
       checked++;
 
       const target = resolveTarget(link, file);

--- a/scripts/generate-embeddings.mjs
+++ b/scripts/generate-embeddings.mjs
@@ -33,21 +33,7 @@ const OUTPUT_FILE = join(OUTPUT_DIR, 'vectors.json');
 const MODEL_NAME = 'Xenova/all-MiniLM-L6-v2';
 
 // Paths to skip (not real content pages)
-const SKIP_PATTERNS = [
-  /\/social\//,
-  /\/node\//,
-  /\/404\//,
-  /\/search\//,
-  /\/sitemap/,
-  /\/robots/,
-  /\/feed/,
-  /\/style-guide\//,
-  /\/pagefind\//,
-  /\/semantic-search\//,
-  /\/css\//,
-  /\/img\//,
-  /\/assets\//,
-];
+const SKIP_PATTERNS = [/\/social\//, /\/node\//, /\/404\//, /\/search\//, /\/sitemap/, /\/robots/, /\/feed/, /\/style-guide\//, /\/pagefind\//, /\/semantic-search\//, /\/css\//, /\/img\//, /\/assets\//];
 
 /**
  * Recursively find all HTML files in a directory.
@@ -100,11 +86,7 @@ function makeSnippet(text, isFirstChunk) {
   if (s.length <= 200) return s;
   // Snap to last sentence end within the 200-char window
   const window = s.slice(0, 200);
-  const sentEnd = Math.max(
-    window.lastIndexOf('. '),
-    window.lastIndexOf('? '),
-    window.lastIndexOf('! ')
-  );
+  const sentEnd = Math.max(window.lastIndexOf('. '), window.lastIndexOf('? '), window.lastIndexOf('! '));
   if (sentEnd > 80) return s.slice(0, sentEnd + 1);
   // Fall back to last space
   const spaceIdx = window.lastIndexOf(' ');
@@ -130,11 +112,7 @@ function chunkText(bodyText) {
     if (end < bodyText.length) {
       // Try to snap to sentence boundary within a 100-char window before the target end
       const window = bodyText.slice(end - 100, end);
-      const sentenceEnd = Math.max(
-        window.lastIndexOf('. '),
-        window.lastIndexOf('? '),
-        window.lastIndexOf('! ')
-      );
+      const sentenceEnd = Math.max(window.lastIndexOf('. '), window.lastIndexOf('? '), window.lastIndexOf('! '));
       if (sentenceEnd !== -1) {
         // +2 to include the punctuation and space
         end = end - 100 + sentenceEnd + 2;
@@ -214,10 +192,14 @@ async function main() {
   const entries = [];
   let pageCount = 0;
   for (const file of allFiles) {
-    const urlPath = '/' + relative(BUILD_DIR, file).replace(/index\.html$/, '').replace(/\.html$/, '/');
+    const urlPath =
+      '/' +
+      relative(BUILD_DIR, file)
+        .replace(/index\.html$/, '')
+        .replace(/\.html$/, '/');
 
     // Skip non-content paths
-    if (SKIP_PATTERNS.some(p => p.test(urlPath))) continue;
+    if (SKIP_PATTERNS.some((p) => p.test(urlPath))) continue;
 
     const html = readFileSync(file, 'utf-8');
     const content = extractContent(html);
@@ -229,9 +211,7 @@ async function main() {
       const chunk = chunks[ci];
       // Chunk 0 gets title + description + body for maximum signal;
       // later chunks get title + body only (description would dilute).
-      const embeddingInput = ci === 0
-        ? content.title + ' ' + content.description + ' ' + chunk.text
-        : content.title + ' ' + chunk.text;
+      const embeddingInput = ci === 0 ? content.title + ' ' + content.description + ' ' + chunk.text : content.title + ' ' + chunk.text;
 
       const entry = {
         url: urlPath,
@@ -268,7 +248,7 @@ async function main() {
     const entry = entries[i];
     const output = await extractor(entry.embeddingInput, { pooling: 'mean', normalize: true });
     // Round to 4 decimal places — well within MiniLM's noise floor, reduces JSON size
-    const embedding = Array.from(output.data).map(v => Math.round(v * 10000) / 10000);
+    const embedding = Array.from(output.data).map((v) => Math.round(v * 10000) / 10000);
 
     const chunk = {
       url: entry.url,
@@ -301,7 +281,7 @@ async function main() {
   // via eleventy.after hook in eleventy.js (runs in both dev and production).
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error('Embedding generation failed:', err);
   process.exit(1);
 });

--- a/src/site/semantic-search.js
+++ b/src/site/semantic-search.js
@@ -47,27 +47,27 @@ export function initSemanticSearch({ esc, setMode }) {
 
     let intro;
     if (results.length === 1) {
-      intro = results[0].score > 0.45
-        ? '<p>I found one post that closely matches:</p>'
-        : '<p>I found one post that might be relevant:</p>';
+      intro = results[0].score > 0.45 ? '<p>I found one post that closely matches:</p>' : '<p>I found one post that might be relevant:</p>';
     } else {
       intro = `<p>Here are ${results.length} posts that might be relevant:</p>`;
     }
 
-    const cards = results.map(r => {
-      const date = formatDate(r.date);
-      const score = Math.round(r.score * 100);
-      const meta = [date, `${score}% match`].filter(Boolean).join(' · ');
-      // Chunk 0 has teaser — its snippet starts at the beginning of the post.
-      // Later chunks start mid-text, so prefix with ellipsis.
-      const prefix = (r.snippet && !r.teaser) ? '\u2026 ' : '';
-      const displayText = r.snippet ? prefix + r.snippet + ' \u2026' : r.teaser || '';
-      return `<div class="kh-ask__result">
+    const cards = results
+      .map((r) => {
+        const date = formatDate(r.date);
+        const score = Math.round(r.score * 100);
+        const meta = [date, `${score}% match`].filter(Boolean).join(' · ');
+        // Chunk 0 has teaser — its snippet starts at the beginning of the post.
+        // Later chunks start mid-text, so prefix with ellipsis.
+        const prefix = r.snippet && !r.teaser ? '\u2026 ' : '';
+        const displayText = r.snippet ? prefix + r.snippet + ' \u2026' : r.teaser || '';
+        return `<div class="kh-ask__result">
         <a href="${esc(r.url)}"><h3>${esc(r.title || r.url)}</h3></a>
         ${displayText ? `<p>${esc(displayText)}</p>` : ''}
         <p class="kh-ask__result-meta">${esc(meta)}</p>
       </div>`;
-    }).join('');
+      })
+      .join('');
 
     const fallback = `<p class="kh-ask__fallback">Not what you were looking for? Switch to <a href="#" onclick="setMode('keyword'); return false;">keyword search</a>.</p>`;
 
@@ -79,10 +79,7 @@ export function initSemanticSearch({ esc, setMode }) {
     const progressBar = statusMsg.querySelector('progress');
 
     // Fetch vectors and import Transformers.js in parallel
-    const [vectorResp, { pipeline: tfPipeline }] = await Promise.all([
-      fetch(VECTORS_URL),
-      import(TRANSFORMERS_URL),
-    ]);
+    const [vectorResp, { pipeline: tfPipeline }] = await Promise.all([fetch(VECTORS_URL), import(TRANSFORMERS_URL)]);
     if (!vectorResp.ok) throw new Error(`Failed to load vectors: ${vectorResp.status}`);
     vectorData = await vectorResp.json();
     if (vectorData.version !== 2) throw new Error('Stale vectors.json — run yarn build to regenerate');
@@ -135,9 +132,9 @@ export function initSemanticSearch({ esc, setMode }) {
       const threshold = query.trim().length < 4 ? 0.15 : 0.25;
       const results = [...bestByUrl.values()]
         .sort((a, b) => b.score - a.score)
-        .filter(d => d.score > threshold)
+        .filter((d) => d.score > threshold)
         .slice(0, 5)
-        .map(d => ({ ...chunks[d.i], score: d.score }));
+        .map((d) => ({ ...chunks[d.i], score: d.score }));
 
       thinkingMsg.remove();
       addMessage('system', renderResults(results, query));

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -42,21 +42,9 @@ const SITE_ORIGIN = 'https://www.allaboutken.com';
 
 // Local dev origins — Referer check allows these in addition to SITE_ORIGIN.
 // Remove or empty this array in production if you prefer stricter validation.
-const DEV_ORIGINS = [
-  'http://localhost',
-  'http://127.0.0.1',
-  'http://192.168.',
-];
+const DEV_ORIGINS = ['http://localhost', 'http://127.0.0.1', 'http://192.168.'];
 
-const BOT_UA_PATTERNS = [
-  'bot', 'crawl', 'spider', 'slurp', 'wget', 'curl',
-  'python-requests', 'go-http-client', 'java/', 'libwww',
-  'httpunit', 'nutch', 'phpcrawl', 'msnbot', 'adidxbot',
-  'blekkobot', 'teoma', 'ia_archiver', 'gigablast', 'yandex',
-  'twiceler', 'mediapartners-google', 'adsbot-google', 'googlebot',
-  'bingbot', 'ahrefsbot', 'semrushbot', 'dotbot', 'petalbot',
-  'bytespider', 'gptbot', 'claudebot',
-];
+const BOT_UA_PATTERNS = ['bot', 'crawl', 'spider', 'slurp', 'wget', 'curl', 'python-requests', 'go-http-client', 'java/', 'libwww', 'httpunit', 'nutch', 'phpcrawl', 'msnbot', 'adidxbot', 'blekkobot', 'teoma', 'ia_archiver', 'gigablast', 'yandex', 'twiceler', 'mediapartners-google', 'adsbot-google', 'googlebot', 'bingbot', 'ahrefsbot', 'semrushbot', 'dotbot', 'petalbot', 'bytespider', 'gptbot', 'claudebot'];
 
 /**
  * Return the request's Origin if it's on the allow list, otherwise SITE_ORIGIN.
@@ -131,12 +119,7 @@ export default {
       // Increment the counter
       const countKey = `count:${type}:${postPath}`;
       const current = parseInt(await env.FEEDBACK_COUNTS.get(countKey), 10) || 0;
-      ctx.waitUntil(
-        Promise.all([
-          env.FEEDBACK_COUNTS.put(countKey, String(current + 1)),
-          env.FEEDBACK_COUNTS.put(rlKey, '1', { expirationTtl: 86400 }),
-        ]),
-      );
+      ctx.waitUntil(Promise.all([env.FEEDBACK_COUNTS.put(countKey, String(current + 1)), env.FEEDBACK_COUNTS.put(rlKey, '1', { expirationTtl: 86400 })]));
 
       return Response.redirect(`${SITE_ORIGIN}/${postPath}/#thanks`, 302);
     }
@@ -144,12 +127,8 @@ export default {
     // --- Count routes: /count/{path}.svg (badge) or /count/{path} (plain text) ---
     if (pathname.startsWith('/count/')) {
       const isSvg = pathname.endsWith('.svg');
-      const postPath = (isSvg
-        ? pathname.slice('/count/'.length, -'.svg'.length)
-        : pathname.slice('/count/'.length)
-      ).replace(/\/$/, '');
-      const count =
-        parseInt(await env.FEEDBACK_COUNTS.get(`count:up:${postPath}`), 10) || 0;
+      const postPath = (isSvg ? pathname.slice('/count/'.length, -'.svg'.length) : pathname.slice('/count/'.length)).replace(/\/$/, '');
+      const count = parseInt(await env.FEEDBACK_COUNTS.get(`count:up:${postPath}`), 10) || 0;
       const corsOrigin = getAllowedOrigin(request);
 
       if (isSvg) {


### PR DESCRIPTION
## Summary

- apply the repository Prettier policy with pinned Prettier 3.6.2 to the five failing first-party JavaScript files
- keep changes formatting-only; no stylesheet, generated build artifact, or unrelated untracked test-file changes

## Validation

- PASS: npx --yes prettier@3.6.2 --check across all tracked JavaScript entry points
- PASS: yarn lint:css
- PASS: yarn build
- PASS: git diff --check
- BASELINE FAILURES: yarn lint:links reports 14 existing broken content links unrelated to these formatting-only changes; the command checked 4,046 links across 256 pages

Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/Users/khawkins/Documents/git/allaboutken-11ty
task-type: lint-fix
task-title: Linter Fixes
provider: codex
score: 0.5
cost-tier: Low (10-50k)
branch: chore/lint-fix-iteration3-js
iterations: 1
duration: 7m55s
run-started: 2026-07-18T02:00:06+02:00
nightshift:metadata -->
