### PR TITLE
chore: add agent guidance and normalize commit messages

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -14,6 +14,19 @@ git config core.hooksPath .githooks
 
 ## Available Hooks
 
+### prepare-commit-msg
+
+Normalizes common commit subject issues before validation:
+
+- Uppercase prefix -> lowercase
+- Spacing around `:` normalized to `<prefix>: <description>`
+- Leading/trailing whitespace trimmed
+- Trailing period removed
+
+It skips machine-generated subjects (`Merge`, `Revert`, `fixup!`, `squash!`).
+
+If a message still does not match the required format after normalization, `commit-msg` blocks the commit.
+
 ### pre-push
 
 Reminds you about PR title format requirements before pushing. This helps catch issues early that would otherwise fail in the `pr-title-check` GitHub Actions workflow.

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -14,7 +14,7 @@ case "$subject" in
 esac
 
 allowed_prefixes="content | feature | fix | ci | chore"
-prefix_pattern='^(content|feature|fix|ci|chore): .+'
+prefix_pattern='^(content|feature|fix|ci|chore): [^[:space:]].*'
 
 fail() {
   echo ""
@@ -31,6 +31,11 @@ fail() {
 
 if ! [[ "$subject" =~ $prefix_pattern ]]; then
   fail "missing or unknown prefix"
+fi
+
+description="${subject#*: }"
+if [[ -z "${description// }" ]]; then
+  fail "empty description"
 fi
 
 if (( ${#subject} > 72 )); then

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -38,8 +38,8 @@ fi
 
 if [[ "$normalized" != "$subject" ]]; then
   tmp_file="$(mktemp)"
-  awk -v line="$subject_line" -v replacement="$normalized" '
-    NR == line { $0 = replacement }
+  replacement="$normalized" awk -v line="$subject_line" '
+    NR == line { $0 = ENVIRON["replacement"] }
     { print }
   ' "$msg_file" > "$tmp_file"
   mv "$tmp_file" "$msg_file"

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Normalizes commit subjects before commit-msg validation.
+set -euo pipefail
+
+msg_file="$1"
+
+subject_line="$(awk '($0 !~ /^#/ && $0 !~ /^[[:space:]]*$/){print NR; exit}' "$msg_file")"
+if [[ -z "${subject_line}" ]]; then
+  exit 0
+fi
+
+subject="$(sed -n "${subject_line}p" "$msg_file")"
+
+# Skip machine-generated subjects.
+case "$subject" in
+  "Merge "*|"Revert "*|"fixup! "*|"squash! "*) exit 0 ;;
+esac
+
+trimmed="$(printf '%s' "$subject" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+
+if [[ "$trimmed" =~ ^([[:alpha:]]+)[[:space:]]*:[[:space:]]*(.*)$ ]]; then
+  raw_prefix="${BASH_REMATCH[1]}"
+  raw_description="${BASH_REMATCH[2]}"
+  prefix="$(printf '%s' "$raw_prefix" | tr '[:upper:]' '[:lower:]')"
+  description="$(printf '%s' "$raw_description" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/\.$//')"
+
+  case "$prefix" in
+    content|feature|fix|ci|chore)
+      normalized="${prefix}: ${description}"
+      ;;
+    *)
+      normalized="$trimmed"
+      ;;
+  esac
+else
+  normalized="$trimmed"
+fi
+
+if [[ "$normalized" != "$subject" ]]; then
+  tmp_file="$(mktemp)"
+  awk -v line="$subject_line" -v replacement="$normalized" '
+    NR == line { $0 = replacement }
+    { print }
+  ' "$msg_file" > "$tmp_file"
+  mv "$tmp_file" "$msg_file"
+fi
+
+exit 0

--- a/.githooks/test-commit-msg-hooks.sh
+++ b/.githooks/test-commit-msg-hooks.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+msg_file="$(mktemp)"
+
+cleanup() {
+  rm -f "$msg_file"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "Hook test failed: $1" >&2
+  exit 1
+}
+
+assert_subject() {
+  local expected="$1"
+  local actual
+  IFS= read -r actual < "$msg_file"
+  [[ "$actual" == "$expected" ]] || fail "expected '$expected', got '$actual'"
+}
+
+printf '%s\n\n%s\n' ' Fix : preserve \n and \t tokens. ' 'Body remains.' > "$msg_file"
+"$hook_dir/prepare-commit-msg" "$msg_file"
+assert_subject 'fix: preserve \n and \t tokens'
+[[ "$(sed -n '3p' "$msg_file")" == 'Body remains.' ]] || fail 'commit body changed'
+"$hook_dir/commit-msg" "$msg_file"
+
+printf '%s\n' 'unknown: description' > "$msg_file"
+if "$hook_dir/commit-msg" "$msg_file" >/dev/null 2>&1; then
+  fail 'unknown prefix was accepted'
+fi
+
+printf '%s\n' 'chore:    ' > "$msg_file"
+"$hook_dir/prepare-commit-msg" "$msg_file"
+if "$hook_dir/commit-msg" "$msg_file" >/dev/null 2>&1; then
+  fail 'empty description was accepted'
+fi
+
+echo 'Commit message hook tests passed.'

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,6 +33,8 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies 📦
         run: yarn install --frozen-lockfile
+      - name: Test Git hooks 🪝
+        run: yarn test
       # Cache the embedding model so it doesn't re-download from HuggingFace
       # on every build. Keyed on the embeddings script (which holds MODEL_NAME),
       # so the cache busts automatically when the model changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,13 +39,21 @@ Examples:
 
 ### General rules
 
+- The `prepare-commit-msg` hook auto-normalizes common subject issues:
+  - Uppercase prefix -> lowercase (for example, `Fix` -> `fix`)
+  - Missing or extra spaces around `:` -> exactly one space
+  - Leading/trailing whitespace trimmed
+  - Trailing period removed
+- Canonical commit subject format remains: `<prefix>: <description>`
+- Allowed commit prefixes: `content|feature|fix|ci|chore`
+- Unknown prefix, empty description, or subject length > 72 still fail in `commit-msg`
 - First line ≤ 72 characters (enforced by the hook)
 - No trailing period on the subject (enforced by the hook)
 - Body optional; when present, focus on the *why* (the diff already shows the *what*)
 - One logical change per commit
 - Never use `--no-verify` or `--no-gpg-sign` to bypass hooks
 
-Commit subjects are enforced locally by `.githooks/commit-msg` (activated on `yarn install` via the `prepare` script). PR titles are enforced in CI by `pr-title-check` for prefix/pattern matching.
+Commit subjects are normalized locally by `.githooks/prepare-commit-msg` and enforced by `.githooks/commit-msg` (activated on `yarn install` via the `prepare` script). PR titles are enforced in CI by `pr-title-check` for prefix/pattern matching.
 
 ## Pull requests
 

--- a/docs/DEVELOPMENT_SETUP.md
+++ b/docs/DEVELOPMENT_SETUP.md
@@ -20,7 +20,7 @@ corepack enable
 yarn install
 ```
 
-`yarn install` runs the `prepare` script and configures repo hooks (`.githooks/commit-msg`).
+`yarn install` runs the `prepare` script and configures the hooks in `.githooks/`, including commit-subject normalization and validation.
 If your shell does not pick up the right Yarn automatically, `corepack` is the supported path here because `packageManager` pins Yarn 1.22.22.
 
 ## Daily development workflow

--- a/docs/GIT_HOOKS.md
+++ b/docs/GIT_HOOKS.md
@@ -15,6 +15,16 @@ git config core.hooksPath .githooks
 
 ## Active hooks
 
+### `.githooks/prepare-commit-msg` (normalizes)
+
+Normalizes the first commit subject line before validation:
+
+- Uppercase prefix -> lowercase
+- Missing/extra spaces around `:` -> exactly one space
+- Leading/trailing whitespace trimmed
+- Trailing period removed
+- Merge/revert/fixup/squash subjects are skipped
+
 ### `.githooks/commit-msg` (enforced)
 
 Checks the commit subject against:
@@ -23,7 +33,10 @@ Checks the commit subject against:
 - Allowed prefixes: `content`, `feature`, `fix`, `ci`, `chore`
 - Subject length: `<= 72` characters
 - No trailing period
+- No empty description
 - Merge/revert/fixup/squash subjects are skipped
+
+If a subject cannot be safely normalized (for example, unknown prefix), the commit is rejected with guidance.
 
 ### `.githooks/pre-push` (advisory)
 
@@ -62,7 +75,7 @@ The workflow does **not** enforce maximum title length or trailing punctuation.
    ls -l .githooks
    ```
 
-   You should see executable permissions on hook files (`commit-msg`, `pre-push`).
+   You should see executable permissions on hook files (`prepare-commit-msg`, `commit-msg`, `pre-push`).
 
 ### CI fails PR title check but local commits succeed
 

--- a/docs/GIT_HOOKS.md
+++ b/docs/GIT_HOOKS.md
@@ -51,6 +51,14 @@ GitHub Actions enforces PR titles in [`.github/workflows/pr-title-check.yml`](..
 
 The workflow does **not** enforce maximum title length or trailing punctuation.
 
+## Testing
+
+Run the commit-message hook regression checks with:
+
+```bash
+yarn test
+```
+
 ## Troubleshooting
 
 ### Hooks are not running

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -11,6 +11,7 @@ Source of truth for local commands and script behavior in this repository.
 | `yarn embeddings` | Regenerate semantic-search vectors | After content/model changes that affect embeddings |
 | `yarn lint:css` | Lint SCSS/CSS files | Before committing style changes |
 | `yarn lint:links` | Validate internal links in `build/` | After a build, to catch broken internal links/anchors |
+| `yarn test` | Test commit-message normalization and validation | After changing files in `.githooks/` |
 
 ## Script details
 
@@ -78,14 +79,15 @@ Source of truth for local commands and script behavior in this repository.
 
 ### `yarn test`
 
-- Placeholder script; currently prints an informational message and exits successfully.
-- There is no automated test suite wired via this command today.
+- Runs `.githooks/test-commit-msg-hooks.sh`.
+- Checks normalization without corrupting literal escape sequences, preservation of the commit body, and rejection of unknown prefixes and empty descriptions.
+- Runs as a required CI step.
 
 ### `yarn prepare`
 
 - Sets Git hooks path: `git config core.hooksPath .githooks`.
 - Normally runs as part of dependency installation lifecycle.
-- Enables local commit-message enforcement via `.githooks/commit-msg`.
+- Enables local commit-message normalization and enforcement via `.githooks/prepare-commit-msg` and `.githooks/commit-msg`.
 
 ## Lifecycle and automation notes
 
@@ -94,8 +96,9 @@ Source of truth for local commands and script behavior in this repository.
 - `yarn install` runs `yarn prepare` automatically.
 - This repository uses that hook to point Git at `.githooks/`, so local commits are validated before they are created.
 
-### Commit message hook (`.githooks/commit-msg`)
+### Commit message hooks
 
+- `.githooks/prepare-commit-msg` normalizes common prefix, spacing, and trailing-period issues.
 - Enforces `<prefix>: <description>` on the commit subject.
 - Allowed prefixes: `content`, `feature`, `fix`, `ci`, `chore`.
 - Enforces subject length <= 72 characters and disallows a trailing period.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "yarn clean && yarn sass && yarn eleventy && yarn embeddings && echo '🏋 Build completed'",
     "dev": "concurrently -k \"sass --load-path src/components --watch --poll src/components/vf-componenet-rollup/index.scss:build/css/styles.css\" \"ELEVENTY_ENV=development eleventy --serve --config=eleventy.js\"",
     "start": "yarn dev",
-    "test": "echo \"Error: no test specified\" && exit 0",
+    "test": "bash .githooks/test-commit-msg-hooks.sh",
     "prepare": "git config core.hooksPath .githooks",
     "update-components": "yarn upgrade-interactive --latest"
   },


### PR DESCRIPTION
## Summary

- link `AGENTS.md` to the existing `CLAUDE.md` project guidance
- normalize common commit-subject formatting before validation while preserving literal escape sequences
- tighten empty-description validation and align the hook documentation
- add commit-message hook regression coverage to `yarn test` and CI

## Testing

- `corepack yarn test`
- `bash -n .githooks/prepare-commit-msg .githooks/commit-msg .githooks/test-commit-msg-hooks.sh`
- `git diff --check`