### PR TITLE
content: Position role around platforms and audience engagement

### DIFF
--- a/src/site/_data/siteConfig.json
+++ b/src/site/_data/siteConfig.json
@@ -1,7 +1,7 @@
 {
   "siteInformation": {
     "title": "All about Ken Hawkins",
-    "short_description": "Digital Platforms & Audience Engagement Lead who translates between executives, developers, and users to build measurable public-facing systems. 20+ years delivering results for UN, science, and media organizations.",
+    "short_description": "Digital Platforms & Audience Engagement Lead who translates between executives, developers, and users to build measurable public-facing systems, and the structured content and data that make them work for people and machines alike. 20+ years delivering results for UN, science, and media organizations.",
     "url": "https://www.allaboutken.com",
     "author": "Ken Hawkins",
     "email": "khawkins98@gmail.com"

--- a/src/site/_data/siteConfig.json
+++ b/src/site/_data/siteConfig.json
@@ -1,7 +1,7 @@
 {
   "siteInformation": {
     "title": "All about Ken Hawkins",
-    "short_description": "Platform Architect & Digital Strategy Lead who translates between executives, developers, and users—building platforms that work, ship on time, and solve real problems. 20+ years delivering measurable results for UN, science, and media organizations. Expert in design systems, performance engineering, and AI-ready architecture.",
+    "short_description": "Digital Platforms & Audience Engagement Lead who translates between executives, developers, and users to build measurable public-facing systems. 20+ years delivering results for UN, science, and media organizations.",
     "url": "https://www.allaboutken.com",
     "author": "Ken Hawkins",
     "email": "khawkins98@gmail.com"

--- a/src/site/_includes/footer.njk
+++ b/src/site/_includes/footer.njk
@@ -1,7 +1,7 @@
 <footer class="kh-footer kh-u-fullbleed kh-u-do-not-print kh-content" role="contentinfo">
   {%- if page.url != "/" %}
   {%- markdown %}
-  <strong>I'm Ken Hawkins</strong>. I lead digital platforms and audience engagement, building public-facing systems that help complex organizations reach, serve, and learn from their audiences. <a href="/">Learn more</a> or <a href="/#hello">get in touch</a>.
+  <strong>I'm Ken Hawkins</strong>. I lead digital platforms and audience engagement, building public-facing systems that help complex organizations reach, serve, and learn from their audiences. I structure their content and data to be usable by people and the machines increasingly reading on their behalf. <a href="/">Learn more</a> or <a href="/#hello">get in touch</a>.
   {% endmarkdown -%}
   {%- endif -%}
 

--- a/src/site/_includes/footer.njk
+++ b/src/site/_includes/footer.njk
@@ -1,7 +1,7 @@
 <footer class="kh-footer kh-u-fullbleed kh-u-do-not-print kh-content" role="contentinfo">
   {%- if page.url != "/" %}
   {%- markdown %}
-  <strong>I'm Ken Hawkins</strong>. I solve online problems and lead platform architecture and strategic transformation for complex digital ecosystems. <a href="/">Learn more</a> or <a href="/#hello">get in touch</a>.
+  <strong>I'm Ken Hawkins</strong>. I lead digital platforms and audience engagement, building public-facing systems that help complex organizations reach, serve, and learn from their audiences. <a href="/">Learn more</a> or <a href="/#hello">get in touch</a>.
   {% endmarkdown -%}
   {%- endif -%}
 

--- a/src/site/cv.njk
+++ b/src/site/cv.njk
@@ -377,8 +377,9 @@ Co-founded TheDigitel.com in 2009 to revolutionize newspaper methodology for the
   <div class="kh-content">
 {% markdown %}
 
-- **[Information architecture](/posts/20170913-fluid-information-architecture.html)**: Design multilingual taxonomies, optimize user journeys, and create [semantic content models](/posts/20180122-content-action-model.html) with [brand-architecture alignment](/posts/20170723-corporate-design-through-ia.html)
-- **Audience engagement**: Connect user journeys, [audience-quality analytics](/work/2026/impact-story-undrr-analytics-infrastructure/), and feedback loops to understand whether platforms reach and serve their intended audiences
+- **[Information architecture](/posts/20170913-fluid-information-architecture.html) & meaning**: Design multilingual taxonomies, [semantic content models](/posts/20180122-content-action-model.html), and [brand-architecture alignment](/posts/20170723-corporate-design-through-ia.html); model the definitions, relationships, and provenance that let content and data act as shared contracts, usable by people and by machine and AI consumers
+- **Audience engagement**: Connect user journeys, [audience-quality analytics](/work/2026/impact-story-undrr-analytics-infrastructure/), and feedback loops to measure whether platforms reach their intended audiences and whether those audiences can trust and act on what they find
+- **Adoption as product quality**: Treat whether distributed users can understand and adopt a platform as a core success measure, not an afterthought
 - **AI-era content systems**: Develop machine-readable metadata and structured publishing workflows informed by [context-aware AI integration](/posts/20250919-smart-ai-integration-context-first/) and [human-centric value](/posts/20250914-ai-and-the-commoditization-of-reference/)
 - **Data visualization**: Create interactive hazard mapping, country risk dashboards, and exportable datasets for decision-makers
 - **Editorial enablement**: Establish automated compliance, accessibility standards, and multilingual workflows

--- a/src/site/cv.njk
+++ b/src/site/cv.njk
@@ -1,7 +1,7 @@
 ---
-title: "Ken Hawkins: Platform Architect & Digital Strategy Lead"
-subtitle: Digital Systems & Cross-Functional Leadership
-teaser: 'CV and experience: 20+ years leading platform architecture, design systems, and strategic transformation for UNDRR, EMBL, media organizations.'
+title: "Ken Hawkins: Digital Platforms & Audience Engagement Lead"
+subtitle: 'Digital Platforms & Audience Engagement Lead'
+teaser: 'CV and experience: 20+ years leading public-facing platforms, audience engagement, design systems, and digital transformation for UNDRR, EMBL, and media organizations.'
 date: 2025-09-27 12:24:50
 layout: layouts/base.njk
 templateEngineOverride: njk, md
@@ -16,7 +16,7 @@ active_path: front
 {# Contact info print #}
 {%- set contactInfoPrint %}
 <div class="kh-u-show-for-print-only">
-<span class="emoji">📧</span>&nbsp; [khawkins98@gmail.com](mailto:khawkins98@gmail.com) &nbsp;<span class="emoji">🐦</span>&nbsp; @khawkins98 &nbsp;<span class="emoji">🌎</span>&nbsp; AllAboutKen.com &nbsp;<span class="emoji">📇</span>&nbsp; Platform Architect & Digital Strategy Lead
+<span class="emoji">📧</span>&nbsp; [khawkins98@gmail.com](mailto:khawkins98@gmail.com) &nbsp;<span class="emoji">🐦</span>&nbsp; @khawkins98 &nbsp;<span class="emoji">🌎</span>&nbsp; AllAboutKen.com &nbsp;<span class="emoji">📇</span>&nbsp; Digital Platforms & Audience Engagement Lead
 </div>
 {% endset -%}
 
@@ -45,7 +45,7 @@ active_path: front
     <div class="kh-u-do-not-print">
       <h1 class="kh-font-headline kh-font-headline--display kh-u-margin__bottom--200 kh-u-show-for-mobile-only">Ken <br/> Hawkins.</span></h1>
       <h1 class="kh-font-headline kh-font-headline--display kh-u-margin__bottom--200 kh-u-show-for-medium-up">Ken Hawkins.</span></h1>
-      <h2 class="kh-font-headline kh-font-headline--display kh-text-heading--1 kh-u-padding__top--500 kh-u-padding__bottom--400">{{subtitle}}.</h2>
+      <h2 class="kh-font-headline kh-font-headline--display kh-text-heading--1 kh-u-padding__top--500 kh-u-padding__bottom--400">{{subtitle}}</h2>
 
     </div>
   </section>
@@ -159,7 +159,7 @@ active_path: front
   </div>
   <div class="kh-content">
 
-Product owner for UNDRR's 15-site public web ecosystem. Lead strategy, platform architecture, content effectiveness, and UX while coordinating component libraries, structured content models ([HIPs](https://www.preventionweb.net/drr-glossary/hips)), shared CMS tooling, and incident response across distributed teams.
+Product owner for UNDRR's 15-site public web ecosystem. Lead digital platform strategy, architecture, audience engagement, and UX while coordinating component libraries, structured content models ([HIPs](https://www.preventionweb.net/drr-glossary/hips)), shared CMS tooling, and incident response across distributed teams.
 
 - **Digital strategy leadership**: Spearheaded organizational transformation across 15-website ecosystem serving global disaster risk community, while positioning UNDRR as AI-ready leader in structured data publishing
 - **Platform transformation**: [Led comprehensive platform transformation](/work/2025/impact-story-platform-recovery-optimization/) across 15-site Drupal ecosystem: 50–70% faster performance, 20% cost savings, 79.9% user satisfaction despite Azure migration challenges
@@ -373,15 +373,16 @@ Co-founded TheDigitel.com in 2009 to revolutionize newspaper methodology for the
 </section>
 
 <section class="kh-grid-stylized kh-u-margin__bottom--600">
-  <h2 class="kh-text-heading--2">Communications Strategy & Content Leadership</h2>
+  <h2 class="kh-text-heading--2">Audience Engagement & Content Systems</h2>
   <div class="kh-content">
 {% markdown %}
 
 - **[Information architecture](/posts/20170913-fluid-information-architecture.html)**: Design multilingual taxonomies, optimize user journeys, and create [semantic content models](/posts/20180122-content-action-model.html) with [brand-architecture alignment](/posts/20170723-corporate-design-through-ia.html)
-- **AI-era content strategy**: Develop machine-readable metadata and structured publishing workflows informed by [context-aware AI integration](/posts/20250919-smart-ai-integration-context-first/) and [human-centric value](/posts/20250914-ai-and-the-commoditization-of-reference/)
+- **Audience engagement**: Connect user journeys, [audience-quality analytics](/work/2026/impact-story-undrr-analytics-infrastructure/), and feedback loops to understand whether platforms reach and serve their intended audiences
+- **AI-era content systems**: Develop machine-readable metadata and structured publishing workflows informed by [context-aware AI integration](/posts/20250919-smart-ai-integration-context-first/) and [human-centric value](/posts/20250914-ai-and-the-commoditization-of-reference/)
 - **Data visualization**: Create interactive hazard mapping, country risk dashboards, and exportable datasets for decision-makers
-- **Editorial governance**: Establish automated compliance, accessibility standards, and multilingual workflows
-- **Campaign development**: Manage end-to-end campaigns from strategy through measurement and optimization
+- **Editorial enablement**: Establish automated compliance, accessibility standards, and multilingual workflows
+- **Campaign platforms**: Build and measure digital experiences that support campaigns from launch through optimization
 
 {% endmarkdown %}
 

--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -1,7 +1,7 @@
 ---
 title: Hello
-subtitle: I am Ken Hawkins.
-teaser: 'Platform Architect & Digital Strategy Lead with 20+ years delivering measurable transformation for UN, science, and media organizations.'
+subtitle: 'Digital Platforms & Audience Engagement Lead'
+teaser: 'Digital Platforms & Audience Engagement Lead helping complex organizations build measurable public-facing systems that serve their audiences.'
 date: 2018-08-22 12:24:50
 image: "/blog/drill-bits.jpg"
 layout: layouts/base.njk
@@ -17,10 +17,12 @@ templateEngineOverride: njk
         <span class="kh-u-text--nowrap">I am</span> Ken Hawkins.
       </div>
     </h1>
-    <h2 class="kh-text-heading--2">I help complex organizations turn their digital presence from information graveyards into measurable systems that work for human and machine audiences alike.</h2>
+    <h2 class="kh-text-heading--2">{{ subtitle }}</h2>
     {% markdown -%}
 
-I ship systems that deliver impact. I understand technology and human organizational dynamics equally — and how to make them work together. Twenty years with [UN agencies, international science, and media](/cv) have sharpened that.
+I lead the public-facing digital systems that help complex organizations reach, serve, and learn from their audiences.
+
+I ship systems that deliver impact. I understand technology and human organizational dynamics equally -- and how to make them work together. Twenty years with [UN agencies, international science, and media](/cv) have sharpened that.
 
     {%- endmarkdown %}
 

--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -1,7 +1,7 @@
 ---
 title: Hello
 subtitle: 'Digital Platforms & Audience Engagement Lead'
-teaser: 'Digital Platforms & Audience Engagement Lead helping complex organizations build measurable public-facing systems that serve their audiences.'
+teaser: 'Digital Platforms & Audience Engagement Lead helping complex organizations build coherent, measurable public-facing systems, with content and data structured to serve both human and machine audiences.'
 date: 2018-08-22 12:24:50
 image: "/blog/drill-bits.jpg"
 layout: layouts/base.njk
@@ -20,7 +20,7 @@ templateEngineOverride: njk
     <h2 class="kh-text-heading--2">{{ subtitle }}</h2>
     {% markdown -%}
 
-I lead the public-facing digital systems that help complex organizations reach, serve, and learn from their audiences.
+I turn fragmented digital estates into coherent, measurable services that help complex organizations reach, serve, and learn from their audiences. I build them so their content and data read clearly to people and to the machines increasingly reading on their behalf.
 
 I ship systems that deliver impact. I understand technology and human organizational dynamics equally -- and how to make them work together. Twenty years with [UN agencies, international science, and media](/cv) have sharpened that.
 

--- a/src/site/style-guide/editorial.njk
+++ b/src/site/style-guide/editorial.njk
@@ -25,7 +25,7 @@ permalink: /style-guide/editorial/
 
 - **Role**: Ken Hawkins -- Digital Platforms & Audience Engagement Lead.
 - **Focus**: information architecture, content architecture, design systems, context engineering, AI practice, Eleventy/Drupal, and pragmatic content tooling.
-- **Unique value**: translating between communications and engineering; show-first, evidence-led writing; reusable, production-ready patterns.
+- **Unique value**: translating between communications and engineering; turning fragmented digital estates into coherent services whose content and data are usable by people and machines alike; show-first, evidence-led writing; reusable, production-ready patterns.
 - **Style anchors**: approachable, specific, generous with links and examples.
 
 ---

--- a/src/site/style-guide/editorial.njk
+++ b/src/site/style-guide/editorial.njk
@@ -23,7 +23,7 @@ permalink: /style-guide/editorial/
 
 ## Author context
 
-- **Role**: Ken Hawkins — web design architect and product-minded editorial lead.
+- **Role**: Ken Hawkins -- Digital Platforms & Audience Engagement Lead.
 - **Focus**: information architecture, content architecture, design systems, context engineering, AI practice, Eleventy/Drupal, and pragmatic content tooling.
 - **Unique value**: translating between communications and engineering; show-first, evidence-led writing; reusable, production-ready patterns.
 - **Style anchors**: approachable, specific, generous with links and examples.


### PR DESCRIPTION
## Summary

- Position myself as a Digital Platforms & Audience Engagement Lead across the homepage, CV, metadata, footer, and editorial author context.
- Add audience-focused supporting copy that makes the outward-facing purpose of the platforms explicit.
- Reframe the CV content-leadership section around audience engagement and content systems, preserving content architecture as a capability without claiming ownership of content strategy.
- **Human + machine audiences (intentionally retained):** the "human and machine audiences" thread removed in the first pass is folded back in, modernized as a forward-looking differentiator rather than legacy architecture jargon. Content and data are now described as structured to be usable by people and by the machines/AI systems increasingly reading on their behalf. The signal appears consistently in the homepage lead, footer, site meta/OG description, editorial author context, and a reworked CV "Information architecture & meaning" bullet.
- Two further durable threads are woven in without reverting the outcome-first voice: coherence-from-fragmentation (turning fragmented digital estates into coherent, measurable services people adopt) and adoption-as-product-quality (a new CV bullet, plus trust/evidence-led language paired with the "measurable results" framing the PR already keeps).

## Test plan

- [x] Full production build passes with semantic-search embeddings regenerated (906 chunks).
- [x] CSS lint passes.
- [x] Rendered HTML checked for the homepage, CV, footer, metadata, and editorial style guide.
- [x] Audience-quality analytics link and all reused CV links resolve in the built site.
- [x] Local link lint reports the same 14 pre-existing unrelated broken links; no new failure introduced.
- [ ] Visual viewport check not completed because the in-app browser was unavailable; review the Vercel preview for title wrapping on the homepage and CV.
