### PR TITLE
chore: normalize commit-message formatting

### DIFF
--- a/.githooks/commit-message-format.sh
+++ b/.githooks/commit-message-format.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Shared commit message format constants used by local git hooks.
+ALLOWED_PREFIXES=("content" "feature" "fix" "ci" "chore")
+SKIP_PREFIXES=("Merge " "Revert " "fixup! " "squash! ")
+MAX_SUBJECT_LENGTH=72

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -5,37 +5,98 @@ set -euo pipefail
 
 msg_file="$1"
 
-# First non-comment, non-empty line is the subject.
-subject="$(grep -v '^#' "$msg_file" | sed '/^[[:space:]]*$/d' | head -n 1 || true)"
-
-# Skip merge, revert, and fixup commits — they are machine-generated.
-case "$subject" in
-  "Merge "*|"Revert "*|"fixup! "*|"squash! "*) exit 0 ;;
-esac
-
-allowed_prefixes="content | feature | fix | ci | chore"
-prefix_pattern='^(content|feature|fix|ci|chore)(\([a-z0-9 ._-]+\))?: .+'
+# Shared format constants.
+allowed_prefixes=("content" "feature" "fix" "ci" "chore")
+skip_prefixes=("Merge " "Revert " "fixup! " "squash! ")
+max_subject_length=72
+scope_pattern='[a-z0-9 ._-]+'
+allowed_prefixes_label="$(printf '%s | ' "${allowed_prefixes[@]}")"
+allowed_prefixes_label="${allowed_prefixes_label% | }"
 
 fail() {
   echo ""
   echo "  ❌  Commit message format error: $1"
   echo ""
   echo "  Expected:  <prefix>[(<scope>)]: <description>"
-  echo "  Prefixes:  ${allowed_prefixes}"
+  echo "  Prefixes:  ${allowed_prefixes_label}"
   echo "  Scope:     optional, e.g. chore(deps): upgrade pagefind"
-  echo "  Rules:     subject ≤ 72 chars, no trailing period"
+  echo "  Rules:     description not empty, exactly one space after ':', subject ≤ ${max_subject_length} chars, no trailing period"
   echo ""
   echo "  Got:  ${subject}"
   echo ""
   exit 1
 }
 
-if ! [[ "$subject" =~ $prefix_pattern ]]; then
+# First non-comment, non-empty line is the subject.
+subject="$(grep -v '^[[:space:]]*#' "$msg_file" | sed '/^[[:space:]]*$/d' | head -n 1 || true)"
+if [[ -z "$subject" ]]; then
+  fail "missing or empty subject"
+fi
+
+# Skip merge, revert, fixup, and squash commits — they are machine-generated.
+for skip_prefix in "${skip_prefixes[@]}"; do
+  if [[ "$subject" == "${skip_prefix}"* ]]; then
+    exit 0
+  fi
+done
+
+if [[ "$subject" == *:* ]]; then
+  prefix_scope="${subject%%:*}"
+  post_colon="${subject#*:}"
+else
   fail "missing or unknown prefix"
 fi
 
-if (( ${#subject} > 72 )); then
-  fail "subject is ${#subject} chars (max 72)"
+# Enforce exactly one space after the colon.
+if [[ "$post_colon" != " "* ]]; then
+  fail "missing or unknown prefix"
+fi
+if [[ "$post_colon" == "  "* ]]; then
+  fail "use exactly one space after colon"
+fi
+
+description="${post_colon# }"
+
+# Split known prefix from optional scope.
+prefix="$prefix_scope"
+scope=""
+
+if [[ "$prefix_scope" == *\(* ]]; then
+  if [[ "$prefix_scope" != *\) ]]; then
+    fail "invalid scope syntax"
+  fi
+
+  scope="${prefix_scope#*\(}"
+  scope="${scope%\)}"
+  prefix="${prefix_scope%%\(*}"
+else
+  if [[ "$prefix_scope" == *[[:space:]]* ]]; then
+    fail "missing or unknown prefix"
+  fi
+fi
+
+is_allowed_prefix=false
+for allowed_prefix in "${allowed_prefixes[@]}"; do
+  if [[ "$prefix" == "$allowed_prefix" ]]; then
+    is_allowed_prefix=true
+    break
+  fi
+done
+
+if [[ "$is_allowed_prefix" != true ]]; then
+  fail "missing or unknown prefix"
+fi
+
+if [[ -n "$scope" && ! "$scope" =~ ^${scope_pattern}$ ]]; then
+  fail "invalid scope"
+fi
+
+if [[ -z "${description//[[:space:]]/}" ]]; then
+  fail "empty description"
+fi
+
+if (( ${#subject} > max_subject_length )); then
+  fail "subject is ${#subject} chars (max ${max_subject_length})"
 fi
 
 case "$subject" in

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -26,6 +26,7 @@ fail() {
 
 # First non-comment, non-empty line is the subject.
 subject="$(grep -v '^[[:space:]]*#' "$msg_file" | sed '/^[[:space:]]*$/d' | head -n 1 || true)"
+subject="$(printf '%s' "$subject" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
 if [[ -z "$subject" ]]; then
   fail "missing or empty subject"
 fi

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -4,13 +4,10 @@
 set -euo pipefail
 
 msg_file="$1"
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${hook_dir}/commit-message-format.sh"
 
-# Shared format constants.
-allowed_prefixes=("content" "feature" "fix" "ci" "chore")
-skip_prefixes=("Merge " "Revert " "fixup! " "squash! ")
-max_subject_length=72
-scope_pattern='[a-z0-9 ._-]+'
-allowed_prefixes_label="$(printf '%s | ' "${allowed_prefixes[@]}")"
+allowed_prefixes_label="$(printf '%s | ' "${ALLOWED_PREFIXES[@]}")"
 allowed_prefixes_label="${allowed_prefixes_label% | }"
 
 fail() {
@@ -20,7 +17,7 @@ fail() {
   echo "  Expected:  <prefix>[(<scope>)]: <description>"
   echo "  Prefixes:  ${allowed_prefixes_label}"
   echo "  Scope:     optional, e.g. chore(deps): upgrade pagefind"
-  echo "  Rules:     description not empty, exactly one space after ':', subject ≤ ${max_subject_length} chars, no trailing period"
+  echo "  Rules:     description not empty, exactly one space after ':', subject ≤ ${MAX_SUBJECT_LENGTH} chars, no trailing period"
   echo ""
   echo "  Got:  ${subject}"
   echo ""
@@ -34,18 +31,18 @@ if [[ -z "$subject" ]]; then
 fi
 
 # Skip merge, revert, fixup, and squash commits — they are machine-generated.
-for skip_prefix in "${skip_prefixes[@]}"; do
+for skip_prefix in "${SKIP_PREFIXES[@]}"; do
   if [[ "$subject" == "${skip_prefix}"* ]]; then
     exit 0
   fi
 done
 
-if [[ "$subject" == *:* ]]; then
-  prefix_scope="${subject%%:*}"
-  post_colon="${subject#*:}"
-else
+if [[ "$subject" != *:* ]]; then
   fail "missing or unknown prefix"
 fi
+
+prefix_scope="${subject%%:*}"
+post_colon="${subject#*:}"
 
 # Enforce exactly one space after the colon.
 if [[ "$post_colon" != " "* ]]; then
@@ -57,10 +54,8 @@ fi
 
 description="${post_colon# }"
 
-# Split known prefix from optional scope.
 prefix="$prefix_scope"
 scope=""
-
 if [[ "$prefix_scope" == *\(* ]]; then
   if [[ "$prefix_scope" != *\) ]]; then
     fail "invalid scope syntax"
@@ -69,14 +64,10 @@ if [[ "$prefix_scope" == *\(* ]]; then
   scope="${prefix_scope#*\(}"
   scope="${scope%\)}"
   prefix="${prefix_scope%%\(*}"
-else
-  if [[ "$prefix_scope" == *[[:space:]]* ]]; then
-    fail "missing or unknown prefix"
-  fi
 fi
 
 is_allowed_prefix=false
-for allowed_prefix in "${allowed_prefixes[@]}"; do
+for allowed_prefix in "${ALLOWED_PREFIXES[@]}"; do
   if [[ "$prefix" == "$allowed_prefix" ]]; then
     is_allowed_prefix=true
     break
@@ -87,16 +78,12 @@ if [[ "$is_allowed_prefix" != true ]]; then
   fail "missing or unknown prefix"
 fi
 
-if [[ -n "$scope" && ! "$scope" =~ ^${scope_pattern}$ ]]; then
-  fail "invalid scope"
-fi
-
 if [[ -z "${description//[[:space:]]/}" ]]; then
   fail "empty description"
 fi
 
-if (( ${#subject} > max_subject_length )); then
-  fail "subject is ${#subject} chars (max ${max_subject_length})"
+if (( ${#subject} > MAX_SUBJECT_LENGTH )); then
+  fail "subject is ${#subject} chars (max ${MAX_SUBJECT_LENGTH})"
 fi
 
 case "$subject" in

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Enforces the commit message convention: <prefix>: <description>
+# Enforces the commit message convention: <prefix>[(<scope>)]: <description>
 # See CONTRIBUTING.md for the full list of prefixes.
 set -euo pipefail
 
@@ -14,14 +14,15 @@ case "$subject" in
 esac
 
 allowed_prefixes="content | feature | fix | ci | chore"
-prefix_pattern='^(content|feature|fix|ci|chore): .+'
+prefix_pattern='^(content|feature|fix|ci|chore)(\([a-z0-9 ._-]+\))?: .+'
 
 fail() {
   echo ""
   echo "  ❌  Commit message format error: $1"
   echo ""
-  echo "  Expected:  <prefix>: <description>"
+  echo "  Expected:  <prefix>[(<scope>)]: <description>"
   echo "  Prefixes:  ${allowed_prefixes}"
+  echo "  Scope:     optional, e.g. chore(deps): upgrade pagefind"
   echo "  Rules:     subject ≤ 72 chars, no trailing period"
   echo ""
   echo "  Got:  ${subject}"

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -12,14 +12,15 @@ if [[ -z "${subject_line}" ]]; then
 fi
 
 subject="$(sed -n "${subject_line}p" "$msg_file")"
+trimmed="$(printf '%s' "$subject" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
 
 for skip_prefix in "${SKIP_PREFIXES[@]}"; do
-  if [[ "$subject" == "${skip_prefix}"* ]]; then
+  if [[ "$trimmed" == "${skip_prefix}"* ]]; then
     exit 0
   fi
 done
 
-trimmed="$(printf '%s' "$subject" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+normalized="$trimmed"
 
 if [[ "$trimmed" =~ ^([^:]*)[[:space:]]*:[[:space:]]*(.*)$ ]]; then
   raw_prefix_scope="$(printf '%s' "${BASH_REMATCH[1]}" | sed -E 's/[[:space:]]+$//')"

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Normalizes commit subjects before commit-msg validation.
+set -euo pipefail
+
+msg_file="$1"
+
+# Shared format constants.
+allowed_prefixes=("content" "feature" "fix" "ci" "chore")
+skip_prefixes=("Merge " "Revert " "fixup! " "squash! ")
+max_subject_length=72
+
+subject_line="$(awk '($0 !~ /^[[:space:]]*#/ && $0 !~ /^[[:space:]]*$/){print NR; exit}' "$msg_file")"
+if [[ -z "${subject_line}" ]]; then
+  exit 0
+fi
+
+subject="$(sed -n "${subject_line}p" "$msg_file")"
+
+for skip_prefix in "${skip_prefixes[@]}"; do
+  if [[ "$subject" == "${skip_prefix}"* ]]; then
+    exit 0
+  fi
+done
+
+trimmed="$(printf '%s' "$subject" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+
+if [[ "$trimmed" =~ ^([^:]*)[[:space:]]*:[[:space:]]*(.*)$ ]]; then
+  raw_prefix_scope="$(printf '%s' "${BASH_REMATCH[1]}" | sed -E 's/[[:space:]]+$//')"
+  raw_description="${BASH_REMATCH[2]}"
+
+  scope=""
+  raw_prefix="$raw_prefix_scope"
+  if [[ "$raw_prefix_scope" == *\(*\) ]]; then
+    raw_prefix="${raw_prefix_scope%%\(*}"
+    scope_body="${raw_prefix_scope#*\(}"
+    scope_body="${scope_body%\)}"
+    scope="(${scope_body})"
+  fi
+
+  normalized_prefix="$(printf '%s' "$raw_prefix" | tr '[:upper:]' '[:lower:]')"
+  is_allowed_prefix=false
+  for allowed_prefix in "${allowed_prefixes[@]}"; do
+    if [[ "$normalized_prefix" == "$allowed_prefix" ]]; then
+      is_allowed_prefix=true
+      break
+    fi
+  done
+
+  if [[ "$is_allowed_prefix" == true ]]; then
+    description="$(printf '%s' "$raw_description" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/\.$//')"
+    normalized="${normalized_prefix}${scope}: ${description}"
+  else
+    normalized="$trimmed"
+  fi
+else
+  normalized="$trimmed"
+fi
+
+if [[ "$normalized" != "$subject" ]]; then
+  tmp_file="$(mktemp)"
+  awk -v line="$subject_line" -v replacement="$normalized" '
+    NR == line { $0 = replacement; }
+    { print }
+  ' "$msg_file" > "$tmp_file"
+  mv "$tmp_file" "$msg_file"
+fi
+
+exit 0

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -3,20 +3,17 @@
 set -euo pipefail
 
 msg_file="$1"
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${hook_dir}/commit-message-format.sh"
 
-# Shared format constants.
-allowed_prefixes=("content" "feature" "fix" "ci" "chore")
-skip_prefixes=("Merge " "Revert " "fixup! " "squash! ")
-max_subject_length=72
-
-subject_line="$(awk '($0 !~ /^[[:space:]]*#/ && $0 !~ /^[[:space:]]*$/){print NR; exit}' "$msg_file")"
+subject_line="$(awk '($0 !~ /^#/ && $0 !~ /^[[:space:]]*$/){print NR; exit}' "$msg_file")"
 if [[ -z "${subject_line}" ]]; then
   exit 0
 fi
 
 subject="$(sed -n "${subject_line}p" "$msg_file")"
 
-for skip_prefix in "${skip_prefixes[@]}"; do
+for skip_prefix in "${SKIP_PREFIXES[@]}"; do
   if [[ "$subject" == "${skip_prefix}"* ]]; then
     exit 0
   fi
@@ -39,7 +36,7 @@ if [[ "$trimmed" =~ ^([^:]*)[[:space:]]*:[[:space:]]*(.*)$ ]]; then
 
   normalized_prefix="$(printf '%s' "$raw_prefix" | tr '[:upper:]' '[:lower:]')"
   is_allowed_prefix=false
-  for allowed_prefix in "${allowed_prefixes[@]}"; do
+  for allowed_prefix in "${ALLOWED_PREFIXES[@]}"; do
     if [[ "$normalized_prefix" == "$allowed_prefix" ]]; then
       is_allowed_prefix=true
       break

--- a/.githooks/test-commit-msg-hooks.sh
+++ b/.githooks/test-commit-msg-hooks.sh
@@ -68,6 +68,14 @@ MSG
 assert_subject 'fix: standardize colon spacing'
 assert_commit_accepts 'colon spacing normalization'
 
+# Scoped prefix is retained and validated.
+cat <<'MSG' > "$msg_file"
+Feature(Search): standardize scoped subjects.
+MSG
+"$hook_dir/prepare-commit-msg" "$msg_file"
+assert_subject 'feature(Search): standardize scoped subjects'
+assert_commit_accepts 'scoped prefix normalization and enforcement'
+
 # Unknown prefix is not rewritten by normalization.
 cat <<'MSG' > "$msg_file"
   unknown  :   should stay untouched.

--- a/.githooks/test-commit-msg-hooks.sh
+++ b/.githooks/test-commit-msg-hooks.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+msg_file="$(mktemp)"
+
+cleanup() {
+  rm -f "$msg_file"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "Hook test failed: $1" >&2
+  exit 1
+}
+
+assert_subject() {
+  local expected="$1"
+  local actual
+  actual="$(sed -n '1p' "$msg_file")"
+  [[ "$actual" == "$expected" ]] || fail "expected subject '$expected', got '$actual'"
+}
+
+assert_commit_accepts() {
+  if ! "$hook_dir/commit-msg" "$msg_file" >/dev/null 2>&1; then
+    fail "$1"
+  fi
+}
+
+assert_commit_rejects() {
+  if "$hook_dir/commit-msg" "$msg_file" >/dev/null 2>&1; then
+    fail "$1"
+  fi
+}
+
+# Uppercase prefix normalization + spacing + trailing period cleanup.
+cat <<'MSG' > "$msg_file"
+  FiX   :  Normalize subject shape.
+MSG
+"$hook_dir/prepare-commit-msg" "$msg_file"
+assert_subject 'fix: Normalize subject shape'
+assert_commit_accepts 'uppercase prefix + spacing + trailing period'
+
+# Trailing period removal.
+cat <<'MSG' > "$msg_file"
+chore: remove trailing period.
+MSG
+"$hook_dir/prepare-commit-msg" "$msg_file"
+assert_subject 'chore: remove trailing period'
+assert_commit_accepts 'trailing-period normalization'
+
+# Leading/trailing whitespace cleanup and body preservation.
+cat <<'MSG' > "$msg_file"
+   content   :   whitespace cleanup.  
+
+Body line must stay.
+MSG
+"$hook_dir/prepare-commit-msg" "$msg_file"
+assert_subject 'content: whitespace cleanup'
+[[ "$(sed -n '3p' "$msg_file")" == 'Body line must stay.' ]] || fail 'commit body changed'
+assert_commit_accepts 'leading/trailing subject whitespace + body preservation'
+
+# Spacing normalization around colon.
+cat <<'MSG' > "$msg_file"
+fix    :    standardize colon spacing.
+MSG
+"$hook_dir/prepare-commit-msg" "$msg_file"
+assert_subject 'fix: standardize colon spacing'
+assert_commit_accepts 'colon spacing normalization'
+
+# Unknown prefix is not rewritten by normalization.
+cat <<'MSG' > "$msg_file"
+  unknown  :   should stay untouched.
+MSG
+"$hook_dir/prepare-commit-msg" "$msg_file"
+assert_subject 'unknown  :   should stay untouched.'
+assert_commit_rejects 'unknown prefix should be rejected'
+
+# Empty description is rejected.
+cat <<'MSG' > "$msg_file"
+feature:
+ 
+MSG
+"$hook_dir/prepare-commit-msg" "$msg_file"
+assert_commit_rejects 'empty description should be rejected'
+
+echo 'Commit message hook tests passed.'

--- a/.githooks/test-commit-msg-hooks.sh
+++ b/.githooks/test-commit-msg-hooks.sh
@@ -33,7 +33,7 @@ assert_commit_rejects() {
   fi
 }
 
-# Uppercase prefix normalization + spacing + trailing period cleanup.
+# Uppercase prefix normalization + colon spacing + trailing period cleanup.
 cat <<'MSG' > "$msg_file"
   FiX   :  Normalize subject shape.
 MSG
@@ -49,7 +49,7 @@ MSG
 assert_subject 'chore: remove trailing period'
 assert_commit_accepts 'trailing-period normalization'
 
-# Leading/trailing whitespace cleanup and body preservation.
+# Leading/trailing subject whitespace cleanup and body preservation.
 cat <<'MSG' > "$msg_file"
    content   :   whitespace cleanup.  
 
@@ -57,6 +57,7 @@ Body line must stay.
 MSG
 "$hook_dir/prepare-commit-msg" "$msg_file"
 assert_subject 'content: whitespace cleanup'
+[[ "$(sed -n '2p' "$msg_file")" == '' ]] || fail 'blank line before body changed'
 [[ "$(sed -n '3p' "$msg_file")" == 'Body line must stay.' ]] || fail 'commit body changed'
 assert_commit_accepts 'leading/trailing subject whitespace + body preservation'
 
@@ -70,7 +71,7 @@ assert_commit_accepts 'colon spacing normalization'
 
 # Scoped prefix is retained and validated.
 cat <<'MSG' > "$msg_file"
-Feature(Search): standardize scoped subjects.
+feature(Search): standardize scoped subjects.
 MSG
 "$hook_dir/prepare-commit-msg" "$msg_file"
 assert_subject 'feature(Search): standardize scoped subjects'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,13 +39,19 @@ Examples:
 
 ### General rules
 
-- First line ≤ 72 characters (enforced by the hook)
-- No trailing period on the subject (enforced by the hook)
+- Commit subject rules are normalized then enforced for the first line only:
+  - `prepare-commit-msg` lowercases known prefixes (`content`, `feature`, `fix`, `ci`, `chore`)
+  - `prepare-commit-msg` normalizes colon spacing to exactly one space
+  - `prepare-commit-msg` trims leading/trailing subject whitespace
+  - `prepare-commit-msg` removes one trailing period
+  - `prepare-commit-msg` leaves unknown prefixes untouched so validation can reject them
+- First line ≤ 72 characters (enforced by `commit-msg`)
+- No trailing period on the subject (enforced by `commit-msg`)
 - Body optional; when present, focus on the *why* (the diff already shows the *what*)
 - One logical change per commit
 - Never use `--no-verify` or `--no-gpg-sign` to bypass hooks
 
-Commit subjects are enforced locally by `.githooks/commit-msg` (activated on `yarn install` via the `prepare` script). PR titles are enforced in CI by `pr-title-check` for the same prefix set and optional scope, but CI does not enforce the 72-character limit or trailing-period rule.
+Commit subjects are normalized by `.githooks/prepare-commit-msg` then enforced by `.githooks/commit-msg` (activated on `yarn install` via the `prepare` script). PR titles are enforced in CI by `pr-title-check` for the same prefix set and optional scope, but CI does not enforce the 72-character limit or trailing-period rule.
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,24 +18,24 @@ One branch per unit of work. If a content post and an unrelated refactor ship to
 
 ## Commit messages
 
-Format: `prefix: sentence-case description`
+Format: `prefix[(scope)]: sentence-case description`
 
 | Prefix | Use for |
 |--------|---------|
-| `content:` | Posts, pages, editorial copy, images |
-| `feature:` | New site functionality or pages |
-| `fix:` | Bug fixes, broken builds, broken links |
-| `ci:` | GitHub Actions, Vercel config, deployment |
-| `chore:` | Deps, tooling, refactoring, procedural docs |
+| `content` | Posts, pages, editorial copy, images |
+| `feature` | New site functionality or pages |
+| `fix` | Bug fixes, broken builds, broken links |
+| `ci` | GitHub Actions, Vercel config, deployment |
+| `chore` | Deps, tooling, refactoring, procedural docs |
 
 Examples:
 
-- `content: Add garage page intro and how-it-works section`
-- `content: Draft post on Vercel proxy for hobby projects`
-- `feature: Add /garage/ index page and data file`
-- `fix: Correct trailing-slash redirect for proxied paths`
-- `ci: Add pinment rewrite and CORS headers to vercel.json`
-- `chore: Upgrade pagefind 1.4.0 → 1.5.2`
+- `content: add garage page intro and how-it-works section`
+- `content: draft post on Vercel proxy for hobby projects`
+- `feature(search): add semantic search results page`
+- `fix: correct trailing-slash redirect for proxied paths`
+- `ci: add pinment rewrite and CORS headers to vercel.json`
+- `chore(deps): upgrade pagefind 1.4.0 to 1.5.2`
 
 ### General rules
 
@@ -45,13 +45,19 @@ Examples:
 - One logical change per commit
 - Never use `--no-verify` or `--no-gpg-sign` to bypass hooks
 
-Commit subjects are enforced locally by `.githooks/commit-msg` (activated on `yarn install` via the `prepare` script). PR titles are enforced in CI by `pr-title-check` for prefix/pattern matching.
+Commit subjects are enforced locally by `.githooks/commit-msg` (activated on `yarn install` via the `prepare` script). PR titles are enforced in CI by `pr-title-check` for the same prefix set and optional scope, but CI does not enforce the 72-character limit or trailing-period rule.
 
 ## Pull requests
 
 One PR per unit of work. Keep noisy refactors out of content PRs.
 
-**Title**: must match CI's enforced pattern (`<prefix>: <description>`) using prefixes `content|feature|fix|ci|chore`. Optional scope is allowed (for example, `chore(deps): ...`).
+**Title**: must match CI's enforced pattern (`<prefix>[(<scope>)]: <description>`) using prefixes `content|feature|fix|ci|chore`.
+
+**Examples**:
+
+- `feature(search): add semantic search results page`
+- `fix: correct trailing-slash redirect`
+- `chore(deps): upgrade pagefind to v1.5.2`
 
 **Body**: use [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). Two sections:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,9 @@ Examples:
 - One logical change per commit
 - Never use `--no-verify` or `--no-gpg-sign` to bypass hooks
 
-Commit subjects are normalized by `.githooks/prepare-commit-msg` then enforced by `.githooks/commit-msg` (activated on `yarn install` via the `prepare` script). PR titles are enforced in CI by `pr-title-check` for the same prefix set and optional scope, but CI does not enforce the 72-character limit or trailing-period rule.
+Commit subjects are normalized by `.githooks/prepare-commit-msg` and enforced by `.githooks/commit-msg` (activated on `yarn install` via the `prepare` script). PR titles are enforced in CI by `pr-title-check` for the same prefix set and optional scope, but CI does not enforce the 72-character limit or trailing-period rule.
+
+`prepare-commit-msg` only normalizes known prefixes and known formatting issues; unknown prefixes are preserved so strict enforcement can reject them.
 
 ## Pull requests
 

--- a/docs/CITATION_WORKFLOW.md
+++ b/docs/CITATION_WORKFLOW.md
@@ -40,3 +40,11 @@ Each subdirectory is a standalone paper adaptation of a published post: restruct
 - The DOI is referenced back from the live CADI post.
 
 Everything past LaTeX-source-in-this-repo (the actual Zenodo upload, ORCID linking, cross-posting) is manual work done outside this repo's build — there's nothing here to automate yet.
+
+## Compiling: staying manual for now
+
+Building `.tex` -> PDF is a manual, occasional step (Overleaf, or local `pdflatex`/`latexmk` per `latex/README.md`), not wired into `yarn build`. At the current volume — a couple of proof-of-concept files, one pilot paper — a compile pipeline would be more machinery than the problem needs.
+
+**If this scales** (papers become a recurring habit rather than an occasional pilot), the realistic next step is [Tectonic](https://tectonic-typesetting.github.io/): a single self-contained binary, drop-in `pdflatex` replacement, fetches missing packages automatically, no TeX Live install required. At that point it's a small addition — `brew install tectonic` plus a `yarn compile:latex` script that shells out to it, same pattern this repo already uses for Sass/Eleventy — and could even run in CI to produce PDFs as build artifacts.
+
+Ruled out for this use case: pure-JS/WASM LaTeX engines (e.g. `latex.js`, SwiftLaTeX). They either only parse a subset of LaTeX (too risky for packages already in use like `hyperref`/`enumitem`) or are built for interactive browser editors, not a build-script invocation. Not worth the integration cost when Overleaf and, later, Tectonic cover the real need.

--- a/docs/CITATION_WORKFLOW.md
+++ b/docs/CITATION_WORKFLOW.md
@@ -1,0 +1,42 @@
+# Citation and DOI workflow
+
+How posts on this site get a durable, citable identifier and get linked into the researcher-discovery ecosystem — without institutional affiliation. Background and rationale: [issue #98](https://github.com/khawkins98/allaboutken-11ty/issues/98).
+
+## Why
+
+allaboutken.com is the canonical source for the writing, but posts here have no persistent identifier and no presence in the tools people actually use to find and cite independent research. The goal is to fix that for select pieces (starting with the CADI framework), so the work can be tracked, circulated, and cited — and so this site's own citations get more rigorous by example.
+
+## Accounts
+
+- **Zenodo**: user `khawkins98` — primary DOI source. CERN-backed, DataCite-registered, free, no peer review required, no institutional affiliation required.
+- **ORCID**: [0009-0009-6728-2237](https://orcid.org/0009-0009-6728-2237) — the canonical researcher identity. Zenodo deposits link to this at submission time, so the work also appears on the ORCID record.
+- **ResearchGate**: [Ken-Hawkins-2](https://www.researchgate.net/profile/Ken-Hawkins-2) — secondary. Keep it cross-linked once a DOI exists; not the primary deposit target.
+
+## Where the LaTeX source lives
+
+`latex/` at the repo root, one subdirectory per piece being adapted (e.g. `latex/cadi-framework/`). See `latex/README.md` for build instructions (Overleaf or a local TeX install — no LaTeX toolchain is assumed to exist in this repo's normal dev environment).
+
+Each subdirectory is a standalone paper adaptation of a published post: restructured with an abstract and paper-style sections, not a raw copy of the site markdown. The post itself stays the canonical, human-readable version; the LaTeX version exists to produce a citable PDF.
+
+## Workflow
+
+1. **Pick a post.** Prioritize pieces with real original framing and reference lists — they read as papers with the least rework. The CADI framework post is the pilot.
+2. **Adapt to LaTeX** in `latex/<piece-name>/main.tex`. Keep the author block consistent: name, "Independent Researcher," ORCID link.
+3. **Build the PDF** (Overleaf or local `pdflatex`/`latexmk`). Check it renders cleanly before depositing.
+4. **Deposit on Zenodo** under user `khawkins98`:
+   - Upload the PDF (and optionally the `.tex` source).
+   - Link ORCID `0009-0009-6728-2237` as the author identifier during submission.
+   - Use metadata that matches the paper: title, abstract, keywords, publication date.
+5. **Cross-link the DOI**:
+   - Back into the original post on allaboutken.com (e.g. a note or citation block).
+   - On the ORCID profile (Zenodo deposits linked at step 4 should sync automatically, but confirm).
+   - On the ResearchGate profile, if the piece is uploaded there too.
+6. **Repeat** for other candidate posts (DRR pieces, emulation notes) once the pilot is validated.
+
+## What "done" looks like for the pilot
+
+- `latex/cadi-framework/main.tex` compiles to a clean PDF.
+- That PDF is deposited on Zenodo with a minted DOI, linked to ORCID `0009-0009-6728-2237`.
+- The DOI is referenced back from the live CADI post.
+
+Everything past LaTeX-source-in-this-repo (the actual Zenodo upload, ORCID linking, cross-posting) is manual work done outside this repo's build — there's nothing here to automate yet.

--- a/docs/CITATION_WORKFLOW.md
+++ b/docs/CITATION_WORKFLOW.md
@@ -21,7 +21,7 @@ Each subdirectory is a standalone paper adaptation of a published post: restruct
 ## Workflow
 
 1. **Pick a post.** Prioritize pieces with real original framing and reference lists — they read as papers with the least rework. The CADI framework post is the pilot.
-2. **Adapt to LaTeX** in `latex/<piece-name>/main.tex`. Keep the author block consistent: name, "Independent Researcher," ORCID link.
+2. **Adapt to LaTeX** in `latex/<piece-name>/main.tex`. Keep the author block consistent: name, "Independent Researcher," ORCID link. [Jenni.ai](https://jenni.ai/) is an optional aid for this step on future pieces — academic-style rewriting and citation lookup — for posts that need more restructuring than a straight condense. Not used for the CADI pilot, and not a substitute for any other step here (no LaTeX compiling, no Zenodo/ORCID integration).
 3. **Build the PDF** (Overleaf or local `pdflatex`/`latexmk`). Check it renders cleanly before depositing.
 4. **Deposit on Zenodo** under user `khawkins98`:
    - Upload the PDF (and optionally the `.tex` source).

--- a/docs/GIT_HOOKS.md
+++ b/docs/GIT_HOOKS.md
@@ -15,12 +15,28 @@ git config core.hooksPath .githooks
 
 ## Active hooks
 
+### `.githooks/prepare-commit-msg` (normalizes)
+
+Normalizes the first commit subject line before validation:
+
+- Detects the first non-empty, non-comment line.
+- Trims leading/trailing whitespace.
+- Skips machine-generated subjects: `Merge`, `Revert`, `fixup!`, `squash!`.
+- For known prefixes, it applies deterministic normalization:
+  - `content`, `feature`, `fix`, `ci`, `chore`
+  - lowercases the prefix
+  - normalizes colon spacing to exactly one space
+  - trims description leading/trailing whitespace
+  - removes one trailing period
+- Unknown prefixes are not rewritten.
+
 ### `.githooks/commit-msg` (enforced)
 
-Checks the commit subject against:
+Validates the final commit subject against:
 
 - Pattern: `<prefix>[(<scope>)]: <description>` (scope is optional)
 - Allowed prefixes: `content`, `feature`, `fix`, `ci`, `chore`
+- Required non-empty description
 - Subject length: `<= 72` characters
 - No trailing period
 - Merge/revert/fixup/squash subjects are skipped
@@ -32,8 +48,18 @@ Checks the commit subject against:
 - ✓ `feature(search): add semantic search results page`
 - ✗ `update deps` ← missing prefix
 - ✗ `chore: update deps.` ← trailing period
+- ✗ `release: create v2.0 release` ← unknown prefix
+
+### `.githooks/test-commit-msg-hooks.sh` (tests)
+
+Run the commit-message normalization and enforcement regression checks with:
+
+```bash
+bash .githooks/test-commit-msg-hooks.sh
+```
 
 ### `.githooks/pre-push` (advisory)
+
 
 Prints pull request title format guidance before push. It does not block the push; CI is the enforcement source of truth.
 
@@ -72,7 +98,7 @@ The workflow does **not** enforce maximum title length or trailing punctuation.
    ls -l .githooks
    ```
 
-   You should see executable permissions on hook files (`commit-msg`, `pre-push`).
+   You should see executable permissions on hook files (`prepare-commit-msg`, `commit-msg`, `pre-push`).
 
 ### CI fails PR title check but local commits succeed
 

--- a/docs/GIT_HOOKS.md
+++ b/docs/GIT_HOOKS.md
@@ -19,11 +19,19 @@ git config core.hooksPath .githooks
 
 Checks the commit subject against:
 
-- Pattern: `<prefix>: <description>`
+- Pattern: `<prefix>[(<scope>)]: <description>` (scope is optional)
 - Allowed prefixes: `content`, `feature`, `fix`, `ci`, `chore`
 - Subject length: `<= 72` characters
 - No trailing period
 - Merge/revert/fixup/squash subjects are skipped
+
+**Examples:**
+- ✓ `chore: update dependencies`
+- ✓ `chore(deps): upgrade pagefind to v1.3`
+- ✓ `fix(auth): correct token expiry check`
+- ✓ `feature(search): add semantic search results page`
+- ✗ `update deps` ← missing prefix
+- ✗ `chore: update deps.` ← trailing period
 
 ### `.githooks/pre-push` (advisory)
 
@@ -35,6 +43,8 @@ GitHub Actions enforces PR titles in [`.github/workflows/pr-title-check.yml`](..
 
 - Pattern: `<prefix>: <description>` (optional scope allowed, for example `chore(deps): ...`)
 - Allowed prefixes: `content`, `feature`, `fix`, `ci`, `chore`
+- Scope is optional and follows the same `(<scope>)` syntax as commit subjects
+- PR titles are not limited to 72 characters and may end with punctuation
 
 The workflow does **not** enforce maximum title length or trailing punctuation.
 

--- a/docs/GIT_HOOKS.md
+++ b/docs/GIT_HOOKS.md
@@ -22,8 +22,7 @@ Normalizes the first commit subject line before validation:
 - Detects the first non-empty, non-comment line.
 - Trims leading/trailing whitespace.
 - Skips machine-generated subjects: `Merge`, `Revert`, `fixup!`, `squash!`.
-- For known prefixes, it applies deterministic normalization:
-  - `content`, `feature`, `fix`, `ci`, `chore`
+- For known prefixes (`content`, `feature`, `fix`, `ci`, `chore`), it applies deterministic normalization:
   - lowercases the prefix
   - normalizes colon spacing to exactly one space
   - trims description leading/trailing whitespace

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Use this page as the entry point for repository documentation. It maps each doc 
 | [`COMPONENTS.md`](COMPONENTS.md) | Component directory structure and Sass/asset build wiring | Contributors editing UI components and styles | You are adding/changing SCSS modules, assets, or component markup |
 | [`DEVELOPMENT_SETUP.md`](DEVELOPMENT_SETUP.md) | Local environment setup, Node/Yarn baseline, and troubleshooting | New contributors and maintainers | You need a reliable local dev environment or need to fix setup issues quickly |
 | [`OFFLINE_SERVICE_WORKER.md`](OFFLINE_SERVICE_WORKER.md) | Offline/service-worker runtime behavior, caching, and update safety notes | Contributors touching service worker behavior or static asset delivery | You are changing `sw.js`, registration flow, or offline cache strategy |
+| [`CITATION_WORKFLOW.md`](CITATION_WORKFLOW.md) | LaTeX-to-DOI workflow for depositing posts on Zenodo, linked to ORCID | Author (Ken) adapting a post for citation | You are converting a post to LaTeX or depositing it on Zenodo |
 
 ## Suggested read paths
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -11,6 +11,7 @@ Source of truth for local commands and script behavior in this repository.
 | `yarn embeddings` | Regenerate semantic-search vectors | After content/model changes that affect embeddings |
 | `yarn lint:css` | Lint SCSS/CSS files | Before committing style changes |
 | `yarn lint:links` | Validate internal links in `build/` | After a build, to catch broken internal links/anchors |
+| `yarn test` | Run commit-message hook regression checks | After editing `.githooks` scripts |
 
 ## Script details
 
@@ -78,8 +79,8 @@ Source of truth for local commands and script behavior in this repository.
 
 ### `yarn test`
 
-- Placeholder script; currently prints an informational message and exits successfully.
-- There is no automated test suite wired via this command today.
+- Runs `.githooks/test-commit-msg-hooks.sh` to validate commit-message normalization and enforcement behavior.
+- Ensures edge cases (normalization and rejections) are covered before commit and PR work.
 
 ### `yarn prepare`
 
@@ -96,9 +97,10 @@ Source of truth for local commands and script behavior in this repository.
 
 ### Commit message hook (`.githooks/commit-msg`)
 
-- Enforces `<prefix>: <description>` on the commit subject.
+- Enforces `<prefix>[(<scope>)]: <description>` on the commit subject.
+- Normalizes common prefix/casing/spacing/punctuation issues via `.githooks/prepare-commit-msg`.
 - Allowed prefixes: `content`, `feature`, `fix`, `ci`, `chore`.
-- Enforces subject length <= 72 characters and disallows a trailing period.
+- Enforces subject length <= 72 characters, non-empty description, and disallows a trailing period.
 - Skips merge/revert/fixup/squash commit subjects.
 - CI checks PR titles in `.github/workflows/pr-title-check.yml` for the same prefix/pattern (`<prefix>: <description>`, optional scope allowed), but does not enforce commit-subject length/punctuation rules.
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -80,7 +80,7 @@ Source of truth for local commands and script behavior in this repository.
 ### `yarn test`
 
 - Runs `.githooks/test-commit-msg-hooks.sh` to validate commit-message normalization and enforcement behavior.
-- Ensures edge cases (normalization and rejections) are covered before commit and PR work.
+- Ensures normalization and rejection edge-cases (uppercase prefix, colon spacing, trailing period, whitespace trimming, body preservation, unknown prefix, empty description) are covered before commit and PR work.
 
 ### `yarn prepare`
 

--- a/latex/README.md
+++ b/latex/README.md
@@ -1,0 +1,21 @@
+# latex/
+
+Source for pieces from allaboutken.com being adapted into citable, LaTeX-formatted documents for deposit on [Zenodo](https://zenodo.org) (user `khawkins98`), cross-linked to [ORCID 0009-0009-6728-2237](https://orcid.org/0009-0009-6728-2237). Background and workflow: `docs/CITATION_WORKFLOW.md`.
+
+## Contents
+
+- `poc-minimal/` — smallest possible document to verify the LaTeX toolchain (Overleaf or a local install) before investing time in a full paper. Build this first.
+- `cadi-framework/` — the pilot: an adaptation of the [CADI framework post](https://www.allaboutken.com/posts/20260609-iterative-pattern-framework/) into paper form, structured for Zenodo deposit.
+
+## Building
+
+No LaTeX distribution is assumed to be installed in this repo's dev environment. Two options:
+
+1. **Overleaf** (recommended, zero local setup): create a new project, upload the `.tex` file, compile.
+2. **Local**: install a TeX distribution (e.g. MacTeX, or `brew install --cask basictex` for a lighter footprint), then from the relevant subdirectory:
+   ```bash
+   pdflatex main.tex
+   ```
+   Run twice if references/citations don't resolve on the first pass.
+
+These files are not wired into the Eleventy build — they're a separate, manually-built artifact track for the citation workflow.

--- a/latex/cadi-framework/main.tex
+++ b/latex/cadi-framework/main.tex
@@ -1,0 +1,348 @@
+% Adapted from the original web post:
+%   "CADI: a prescriptive path for slop-free AI in content work"
+%   https://www.allaboutken.com/posts/20260609-iterative-pattern-framework/
+% Restructured into paper form as a proof of concept for depositing on
+% Zenodo (user: khawkins98) with an ORCID-linked author record.
+\documentclass[11pt]{article}
+
+\usepackage[margin=1in]{geometry}
+\usepackage{hyperref}
+\usepackage{enumitem}
+\usepackage{parskip}
+
+\title{CADI: A Prescriptive Framework for Evidence-Based AI-Assisted Content Work}
+\author{%
+  Ken Hawkins\thanks{Independent Researcher.} \\
+  \href{https://orcid.org/0009-0009-6728-2237}{ORCID: 0009-0009-6728-2237}
+}
+\date{June 2026}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+Most AI-writing assistance starts cold on every task: no memory of what
+worked last time, no documented picture of an organisation's voice or
+standards. The common responses --- better prompting, a static style
+guide, a bolted-on agent --- each capture part of the answer but not
+the order or the combination. This paper presents CADI (Collect,
+Analyze, Document, Iterate), a four-phase, evidence-based loop for
+deriving AI writing guidance from an organisation's own best content
+and revising that guidance on measured outcomes rather than intuition.
+The framework is illustrated with a case study from UNDRR (the UN
+Office for Disaster Risk Reduction) and situated against related work
+in voice-profile tooling, prompt-engineering evaluation, and clinical
+guideline methodology.
+\end{abstract}
+
+\section{The problem: every prompt starts from zero}
+
+Most AI writing assistance starts cold every time. There is no memory
+of what worked last time, and no sense of an organisation's voice, its
+standards, or its audience. The result is generic, confident output
+that must be corrected after the fact.
+
+The fix is not a better prompt. It is giving the model a documented
+picture of what ``good'' looks like for a specific organisation, and a
+way to improve that picture as more is learned about what works. Done
+well, the model becomes more useful over time rather than requiring
+the same corrective effort on every task.
+
+A failure mode persists even once this is addressed: \emph{confident
+wrongness with silent drift}. Output sounds authoritative but cites a
+source incorrectly, or lands near the target word count while quietly
+shifting the intended meaning. These errors are harder to catch than
+obvious nonsense, and they compound faster.
+
+\section{Supervised co-writing as the starting point}
+
+Most people using AI for writing are not doing autonomous AI
+publishing. They are doing \emph{supervised co-writing}: the model
+handles a first pass or a tedious sub-task, a human reviews and
+corrects, and a human publishes. That is the normal case, and it is
+where most of the current value sits.
+
+CADI targets teams who want to move from ``AI is something we
+sometimes use'' toward ``AI is something our editorial standards
+reliably shape.'' That transition does not happen through prompting
+technique alone; it requires a documented, testable, and revisable
+guidance layer.
+
+\section{Preconditions}
+
+The framework works best when an organisation can answer yes to the
+following:
+
+\begin{itemize}[nosep]
+  \item There are ideally 50+ published items considered high quality
+        (not merely recent). Ten to twenty items from a narrow,
+        high-quality domain still work, at the cost of some
+        overfitting; the discipline of running the loop is what
+        compounds over time.
+  \item Some quality signal exists: engagement data, editor picks,
+        longevity tags, or manual curation.
+  \item At least one person has time to own the guidance document and
+        keep it current.
+  \item Content can be exported from the CMS in text form (Markdown,
+        HTML, or CSV).
+  \item Editors are willing to log failures rather than silently
+        fixing them.
+\end{itemize}
+
+None of this requires a data-science team, a custom CMS, or a formal
+AI strategy. If no one will own the guidance document, however, the
+method breaks down regardless of tooling.
+
+\section{The CADI framework}
+
+CADI is a four-phase loop, built once and then run continuously on its
+final phase. Each cycle sharpens the guidance document rather than
+adding to its weight.
+
+\subsection{C --- Collect: extract the best examples}
+
+An organisation's best content already embodies its patterns: word
+counts, title structures, tag usage, narrative flow. The task is to
+curate an exemplary set, not simply pull the most recent items.
+
+Work within a single content subtype at a time. Most organisations
+publish several superficially similar formats --- press releases,
+news briefs, feature reports, donor updates, blog posts --- each with
+its own voice and structure; mixing them yields average patterns that
+fit none of them.
+
+Top-traffic items are the obvious and most common wrong default.
+High traffic often correlates with topic timeliness or reach rather
+than the qualities worth reproducing. Three signals combine better:
+
+\begin{itemize}[nosep]
+  \item \textbf{Editorial investment} --- items the team spent the
+        most time on, since effort is a quality signal even absent
+        strong metrics.
+  \item \textbf{Aspirational fit} --- items the organisation wants
+        more of its output to resemble.
+  \item \textbf{Performance for type} --- a press release performing
+        at five times the median for press releases is more
+        informative than a single feature that went viral.
+\end{itemize}
+
+Existing reference material --- style guides, brand guidelines,
+glossaries, terminology lists, institutional memos --- should be
+added alongside the corpus. The corpus shows the model what good looks
+like by example; the reference material states the rules to enforce
+and should be citable directly in generated drafts.
+
+\emph{Exit criterion:} 50--100 items in one consolidated, cleaned
+document; a written record of why they qualify; an editor's spot-check
+for outliers.
+
+\subsection{A --- Analyze: find quantitative patterns}
+
+The curated examples are fed to a model with a structured prompt to
+extract empirical description, not yet guidance:
+
+\begin{itemize}[nosep]
+  \item Average word counts, with ranges, by content type
+  \item Title formats and syntactic shapes
+  \item Heading and structural patterns
+  \item Voice markers (person, contractions, hedging, sentence-length
+        variance)
+  \item Source treatment (inline links, blockquotes, first-paragraph
+        attribution)
+  \item Opening and closing patterns
+  \item Cross-linking density
+  \item Metadata usage
+\end{itemize}
+
+This list is not exhaustive; each content subtype has its own tells,
+and the signals watched for should be documented so they can be
+revisited on the next cycle. Models handle the extraction well; the
+interpretation remains a human judgment.
+
+\emph{Exit criterion:} a written summary of patterns with numbers,
+reviewed by at least one editor for anything unrepresentative.
+
+\subsection{D --- Document: turn patterns into working instructions}
+
+The Analyze output is combined with existing institutional knowledge
+into a single document the AI tool uses as standing context. Where an
+existing style guide already covers a subtype, the Document step
+tightens it with the Analyze step's numbers rather than re-deriving it
+from scratch, overriding only where there is evidence the prior
+guidance was wrong.
+
+Observed patterns and existing rules will sometimes conflict --- for
+example, an 8-word average title length against a house-style cap of
+6. The decision, and its rationale, belongs in a change log rather
+than remaining implicit.
+
+The result is guidance concrete enough to act on (``180 words
+$\pm$10\%'') rather than vague (``be concise''); the same document also
+serves human editors.
+
+\emph{Exit criterion:} the instructions reviewed by an editor not
+involved in writing them, and integrated with the AI tool in use.
+
+\subsection{I --- Iterate: build confidence over time}
+
+Iteration done badly is tweaking in the dark. Done well, it is
+hypothesis-driven, for example:
+
+\begin{itemize}[nosep]
+  \item \emph{If} explicit numeric targets are added (``180 words
+        $\pm$10\%''), \emph{then} first-pass acceptance rises from 40\%
+        to 70\% (illustrative).
+  \item \emph{If} exemplars of title styles are shown, \emph{then} the
+        model chooses appropriate titles 85\% of the time
+        (illustrative).
+  \item \emph{If} oppositional review is run (a second model critiques
+        the guidance), \emph{then} biased rules are caught 80\% of the
+        time (illustrative).
+\end{itemize}
+
+Hypotheses are tested with a simple before/after comparison on real
+content, a concrete outcome metric, and a written record of what
+changed and why. For a small team (two to three editors), 20--30 items
+per condition supports an honest qualitative comparison --- an
+improvement over blind tweaking, though not a statistical signal.
+Genuine statistical rigor requires much larger, blinded samples that
+most editorial teams will not reach; qualitative honesty about what
+changed and why is the realistic bar.
+
+A mid-cycle revision trigger applies when more than 20\% of a week's
+outputs fail the same check: that pattern warrants investigation
+immediately rather than waiting for a scheduled audit.
+
+\emph{Exit criterion:} at least one completed hypothesis test, a
+documented decision (kept or rejected), and a failure log someone is
+actively adding to.
+
+\section{Case study: CADI at UNDRR}
+
+One full loop illustrates the framework in practice:
+
+\begin{itemize}[nosep]
+  \item \textbf{Collection}: 122 publications flagged as
+        ``evergreen + high-engagement'' in Drupal.
+  \item \textbf{Analysis}: the model extracted patterns --- 169-word
+        average, 56\% of titles using colons, all items using two to
+        four themes.
+  \item \textbf{Documentation}: a guidance document was drafted and
+        uploaded as standing instructions in Microsoft 365 Copilot.
+  \item \textbf{Iteration}: quarterly audits checked whether new AI
+        drafts matched the documented patterns, with a shared change
+        log recording adjustments and rationale.
+\end{itemize}
+
+Before CADI, none of curation, pattern extraction, guidance
+documentation, or iteration reliably produced anything usable in
+isolation; each task restarted from nothing. Running them as a
+connected loop converted a set of one-off attempts into a continuous,
+improving process. The value was not a single headline metric but the
+conversion of ad hoc effort into something repeatable. This case is
+not offered as rigorous evidence: a prospective, quantified A/B test
+of which guidance changes move which outcomes by how much remains the
+missing piece, and is the direction future cycles should move toward.
+
+\section{Where this breaks down}
+
+Iteration reverts to guesswork under several conditions:
+
+\begin{enumerate}[nosep]
+  \item \textbf{Encoding bias without inspection} --- a pattern such
+        as ``short sentences are good'' may simply reflect that the
+        exemplars targeted beginners; applied universally, it
+        infantilizes advanced content.
+  \item \textbf{Optimizing for fit rather than truth} --- ``this tag
+        co-occurs 26\% of the time, so always pair them'' should read
+        ``consider pairing them.''
+  \item \textbf{No quality gate on the source set} --- mediocre
+        content in the ``best'' set skews guidance toward mediocrity.
+  \item \textbf{Stopping too early or too late} --- ten examples is
+        too few; five hundred risks overfitting.
+  \item \textbf{Expecting voice cloning in informal genres} ---
+        style-imitation performs well for structured formats such as
+        news and email, and considerably worse for informal, personal
+        writing such as blogs and forum posts; corpus-derived guidance
+        reliably reproduces structure and convention, but a
+        distinctive personal voice still requires a human pass.
+\end{enumerate}
+
+Mitigations include transparent curation criteria, documented
+assumptions, human review between cycles, oppositional analysis (a
+second model critiquing the instructions), and explicit escape hatches
+(``usually X, unless Y'').
+
+CADI also does not fit cleanly for high-volume newsrooms shipping
+dozens of pieces per week across many content subtypes; it assumes one
+primary subtype at a time and a corpus small enough to read in full.
+Sampling methodology and per-subtype parallel runs would be needed at
+that scale, and are out of scope here.
+
+\section{Related work}
+
+None of the individual pieces of CADI are novel in isolation; the
+contribution is the connected loop.
+
+Commercial tools such as Writer and Jasper reverse-engineer a voice
+profile from an organisation's own content, functioning as
+implementations of the Collect and Analyze phases. ChainForge (CHI
+2024) formalized treating prompts, and the criteria used to evaluate
+them, as testable hypotheses --- the same posture CADI takes toward
+its own guidance document. Clinical guideline methodology (AGREE II
+and GRADE) assesses whether guidelines are evidence-based and
+implementable; the Australian COVID-19 living guidelines went further,
+revising and republishing weekly for 24 weeks as new evidence arrived
+--- a continuously iterated guidance document running in production.
+
+A software subscription is not a method, and a research paper is not a
+guide. What appears missing elsewhere is the connected discipline:
+deriving guidance from a curated, organisation-specific corpus, then
+maintaining the failure log and test record that make that guidance
+revisable on evidence rather than intuition. That combination is what
+CADI names.
+
+\section{Conclusion}
+
+CADI is best understood as a forcing function rather than a generator:
+most of the underlying work is still careful reading of an
+organisation's own content. The framework's contribution is ensuring
+that reading happens, and that what is learned from it gets written
+down, tested, and revised. It is presented here as the method run
+in production at UNDRR; adaptation should be expected for different
+volumes, content types, and organisational constraints.
+
+\section*{References}
+
+\begin{enumerate}[nosep]
+  \item Bsharat et al., ``Principled Instructions Are All You Need,''
+        \href{https://arxiv.org/abs/2312.16171}{arXiv:2312.16171}.
+  \item ``Catch Me If You Can? Not Yet: LLMs Still Struggle to Imitate
+        the Implicit Writing Styles of Everyday Authors,'' EMNLP 2025
+        Findings, \href{https://arxiv.org/abs/2509.14543}{arXiv:2509.14543}.
+  \item Wu et al., ``ScatterShot: Interactive In-context Example
+        Curation for Text Transformation,'' ACM IUI 2023,
+        \href{https://arxiv.org/abs/2302.07346}{arXiv:2302.07346}.
+  \item Arawjo et al., ``ChainForge: A Visual Toolkit for Prompt
+        Engineering and LLM Hypothesis Testing,'' CHI 2024,
+        \href{https://arxiv.org/abs/2309.09128}{arXiv:2309.09128}.
+  \item Tendal et al., ``Weekly updates of national living
+        evidence-based guidelines: methods for the Australian living
+        guidelines for care of people with COVID-19,'' \emph{Journal
+        of Clinical Epidemiology}, 2020,
+        \href{https://pmc.ncbi.nlm.nih.gov/articles/PMC7657075/}{PMC7657075}.
+  \item Wei et al., ``Chain-of-Thought Prompting Elicits Reasoning,''
+        2022, \href{https://arxiv.org/abs/2201.11903}{arXiv:2201.11903}.
+  \item Yao et al., ``Tree of Thoughts: Deliberate Problem Solving with
+        LLMs,'' 2023, \href{https://arxiv.org/abs/2305.10601}{arXiv:2305.10601}.
+  \item Kohavi, Longbotham et al., ``Controlled experiments on the
+        web: survey and practical guide,'' \emph{Data Mining and
+        Knowledge Discovery}, 2009,
+        \href{https://doi.org/10.1007/s10618-008-0114-1}{doi:10.1007/s10618-008-0114-1}.
+  \item AGREE II --- \href{https://www.agreetrust.org/}{agreetrust.org}.
+  \item GRADE --- \href{https://www.gradeworkinggroup.org/}{gradeworkinggroup.org}.
+  \item Di\'ataxis --- \href{https://diataxis.fr/}{diataxis.fr}.
+  \item PRISMA --- \href{https://www.prisma-statement.org/}{prisma-statement.org}.
+\end{enumerate}
+
+\end{document}

--- a/latex/poc-minimal/minimal.tex
+++ b/latex/poc-minimal/minimal.tex
@@ -1,0 +1,44 @@
+% Proof of concept: verifies a plain article-class document compiles cleanly
+% before investing time in the full cadi-framework paper. Compile with
+% `pdflatex minimal.tex` or upload to Overleaf.
+\documentclass[11pt]{article}
+
+\usepackage[margin=1in]{geometry}
+\usepackage{hyperref}
+
+\title{Toolchain Check: LaTeX to PDF for Zenodo Deposit}
+\author{%
+  Ken Hawkins\thanks{Independent Researcher.} \\
+  \href{https://orcid.org/0009-0009-6728-2237}{ORCID: 0009-0009-6728-2237}
+}
+\date{\today}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+This document exists only to confirm that a plain \texttt{article}-class
+LaTeX source compiles to a PDF suitable for upload to Zenodo, with an
+author block that carries an ORCID identifier. If this builds cleanly,
+the same structure is reused in \texttt{latex/cadi-framework/main.tex}.
+\end{abstract}
+
+\section{Purpose}
+
+Before formatting a full paper, confirm the basics: title, author,
+ORCID link, abstract, a section, and a reference all render correctly
+and the PDF opens without errors.
+
+\section{Sample reference}
+
+A minimal citation, formatted by hand rather than via BibTeX for this
+proof of concept: Kohavi, Longbotham et al., ``Controlled experiments
+on the web: survey and practical guide,'' \emph{Data Mining and
+Knowledge Discovery}, 2009.
+
+\section{Next step}
+
+Once this compiles and looks right, move to
+\texttt{latex/cadi-framework/main.tex} for the real pilot content.
+
+\end{document}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "yarn clean && yarn sass && yarn eleventy && yarn embeddings && echo '🏋 Build completed'",
     "dev": "concurrently -k \"sass --load-path src/components --watch --poll src/components/vf-componenet-rollup/index.scss:build/css/styles.css\" \"ELEVENTY_ENV=development eleventy --serve --config=eleventy.js\"",
     "start": "yarn dev",
-    "test": "echo \"Error: no test specified\" && exit 0",
+    "test": "bash .githooks/test-commit-msg-hooks.sh",
     "prepare": "git config core.hooksPath .githooks",
     "update-components": "yarn upgrade-interactive --latest"
   },

--- a/src/site/scripts.js
+++ b/src/site/scripts.js
@@ -1,4 +1,12 @@
-// This is the "Offline copy of pages" service worker
+/**
+ * Service Worker Registration Script
+ *
+ * This script is responsible for registering the "Offline copy of pages" service worker.
+ * By setting the scope to '/', the service worker controls the entire domain, allowing it
+ * to intercept and cache all network requests for offline fallback functionality.
+ *
+ * This script should be loaded on all pages where offline capabilities are desired.
+ */
 if ('serviceWorker' in navigator) {
   // Always attempt to register; the browser will update existing registrations as needed
   navigator.serviceWorker

--- a/src/site/sw.js
+++ b/src/site/sw.js
@@ -1,18 +1,28 @@
-// This is the "Offline copy of pages" service worker
-const CACHE = "pwabuilder-offline";
+/**
+ * Service Worker: Offline copy of pages
+ *
+ * Implements a "Network falling back to cache" strategy for offline support.
+ *
+ * Strategy details:
+ * 1. During install, the root page (offline fallback) is pre-cached.
+ * 2. On fetch (GET requests only), the service worker tries the network first.
+ * 3. If the network request succeeds, the response is copied to the cache (caching pages as the user visits them).
+ * 4. If the network request fails (e.g., user is offline), the service worker serves the requested resource from the cache.
+ */
+const CACHE = 'pwabuilder-offline';
 
 // TODO: replace the following with the correct offline fallback page i.e.: const offlineFallbackPage = "index.html";
-const offlineFallbackPage = "index.html";
+const offlineFallbackPage = 'index.html';
 
 // Install stage sets up the index page (home page) in the cache and opens a new cache
-self.addEventListener("install", function (event) {
-  console.log("[PWA Builder] Install Event processing");
+self.addEventListener('install', function (event) {
+  console.log('[PWA Builder] Install Event processing');
 
   event.waitUntil(
     caches.open(CACHE).then(function (cache) {
-      console.log("[PWA Builder] Cached offline page during install");
+      console.log('[PWA Builder] Cached offline page during install');
       return cache.add(offlineFallbackPage);
-    })
+    }),
   );
   // Activate the new service worker as soon as it's finished installing
   self.skipWaiting();
@@ -24,13 +34,13 @@ self.addEventListener('activate', (event) => {
 });
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
-self.addEventListener("fetch", function (event) {
-  if (event.request.method !== "GET") return;
+self.addEventListener('fetch', function (event) {
+  if (event.request.method !== 'GET') return;
 
   event.respondWith(
     fetch(event.request)
       .then(function (response) {
-        console.log("[PWA Builder] add page to offline cache: " + response.url);
+        console.log('[PWA Builder] add page to offline cache: ' + response.url);
 
         // If request was success, add or update it in the cache
         event.waitUntil(updateCache(event.request, response.clone()));
@@ -38,12 +48,22 @@ self.addEventListener("fetch", function (event) {
         return response;
       })
       .catch(function (error) {
-        console.log("[PWA Builder] Network request Failed. Serving content from cache: " + error);
+        console.log('[PWA Builder] Network request Failed. Serving content from cache: ' + error);
         return fromCache(event.request);
-      })
+      }),
   );
 });
 
+/**
+ * Retrieves a requested resource from the offline cache.
+ *
+ * Checks the defined offline cache for a match to the incoming request.
+ * If the resource is not found or has a 404 status, it returns a rejected promise,
+ * allowing the fetch event to gracefully handle the missing resource.
+ *
+ * @param {Request} request - The HTTP request to look up in the cache.
+ * @returns {Promise<Response>} A promise that resolves to the cached Response, or rejects if no match is found.
+ */
 function fromCache(request) {
   // Check to see if you have it in the cache
   // Return response
@@ -51,7 +71,7 @@ function fromCache(request) {
   return caches.open(CACHE).then(function (cache) {
     return cache.match(request).then(function (matching) {
       if (!matching || matching.status === 404) {
-        return Promise.reject("no-match");
+        return Promise.reject('no-match');
       }
 
       return matching;
@@ -59,6 +79,16 @@ function fromCache(request) {
   });
 }
 
+/**
+ * Updates the offline cache with a successful network response.
+ *
+ * This function caches pages and assets dynamically as the user navigates the site,
+ * ensuring they are available for future offline access.
+ *
+ * @param {Request} request - The HTTP request used as the cache key.
+ * @param {Response} response - The successful HTTP response to store in the cache.
+ * @returns {Promise<void>} A promise that resolves when the cache is successfully updated.
+ */
 function updateCache(request, response) {
   return caches.open(CACHE).then(function (cache) {
     return cache.put(request, response);


### PR DESCRIPTION
## Summary
- add .githooks/prepare-commit-msg with deterministic normalization
- harden .githooks/commit-msg enforcement with shared constants and clearer validation
- add regression tests and docs updates for commit message behavior

## Test plan
- bash .githooks/test-commit-msg-hooks.sh