### PR TITLE
content: digesting entry on startup culture lessons

### DIFF
--- a/src/site/posts/20260809-digesting-startup-culture.njk
+++ b/src/site/posts/20260809-digesting-startup-culture.njk
@@ -1,0 +1,33 @@
+---
+title: "We act like startups but skip their hard-won lessons"
+layout: layouts/digesting.njk
+teaser: "John Ousterhout's 2021 note on startup culture reads better now that AI, thinner budgets, and constant iteration have pushed startup habits into organizations that were never built for them."
+date: 2026-08-09
+digest_link: https://web.stanford.edu/~ouster/cgi-bin/startupCulture.php
+tags: digesting
+topics:
+  - software engineering > team culture
+  - project management
+  - productivity
+kens_status: published
+---
+
+{% markdown %}
+
+John Ousterhout, who wrote [*A Philosophy of Software Design*](https://web.stanford.edu/~ouster/cgi-bin/aposd.php), put out a short [note on startup company culture](https://web.stanford.edu/~ouster/cgi-bin/startupCulture.php) back in 2021. It is five years old and aimed squarely at startups, and I think it reads better now than when he wrote it.
+
+A lot of us are running like a startup without realizing it. Budgets are thinner, AI is getting pushed into every workflow, and the instruction from every direction is the same: iterate faster. We are running startups inside organizations that were never built to be one, mostly without calling it that.
+
+Startups spent decades working out how to move fast without falling apart. Ousterhout's five principles are that lesson, and none of it is startup-specific; it is just what any team needs when the pace goes up. Better borrowed on purpose than relearned the hard way.
+
+He sums it up near the end: "a highly iterative culture where we move quickly but make constant corrections." The five principles, with my take on each:
+
+- **It's OK to make mistakes.** Speed guarantees errors; the unforgivable ones are hiding them or repeating them.
+- **We want to know about problems.** Say it early; a surprise at the deadline costs far more than an awkward heads-up now.
+- **Success is execution plus consultation.** The quiet nod-then-miss is the real failure, not the miss itself.
+- **Get lots of input, then move.** Consult as wide as the decision is big, then actually decide.
+- **The reasonable person principle.** Assume good faith and ask before you attack; defensiveness burns the energy you need to correct course.
+
+None of this needs a startup to work. It needs a team that treats a caught mistake as a normal Tuesday, which is what a lot of us in older, slower organizations are quietly trying to build. Five years old, written for startups, and worth your ten minutes.
+
+{% endmarkdown %}


### PR DESCRIPTION
Adds a digesting entry on John Ousterhout's 2021 note on startup company culture.

Angle: many of us are behaving like startups (thinner budgets, AI in every workflow, iterate-faster pressure) without drawing on the hard-won lessons startups already learned — and those lessons aren't startup-specific. Summarizes Ken's one-line take on each of Ousterhout's five principles.

Small content-only change.