### PR TITLE
fix: eliminate horizontal overflow at device widths

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:css:fix": "stylelint \"src/**/*.scss\" \"src/**/*.css\" --fix",
     "lint:links": "node scripts/check-links.mjs",
     "lint:css-vars": "node scripts/check-css-vars.mjs",
+    "lint:overflow": "node scripts/check-overflow.mjs",
     "related": "node scripts/compute-related.mjs",
     "semantic-map": "node scripts/compute-semantic-map.mjs",
     "story-lab": "node scripts/compute-story-lab.mjs",

--- a/scripts/check-overflow.mjs
+++ b/scripts/check-overflow.mjs
@@ -1,0 +1,168 @@
+/**
+ * Fail on horizontal overflow at real device widths.
+ *
+ * Why a browser is required: horizontal overflow is a layout outcome, not a
+ * property of the CSS. A long unbreakable URL, a wide table, a new full-bleed
+ * element or a `100vw` next to a scrollbar all produce it, and none is visible
+ * by reading the stylesheet.
+ *
+ * Why mobile emulation specifically: without it, headless Chrome ignores the
+ * `width=device-width` viewport meta and lays a narrow window out as a desktop
+ * page. That reports the whole site as broken below ~640px, which is an
+ * artifact of the harness rather than a fact about the site -- a false alarm
+ * this check exists partly to stop anyone raising twice.
+ *
+ * Baseline when written (Aug 2026): clean at 320/360/390/414 and at desktop
+ * widths. The only real offender found was the inline search box overflowing
+ * 320px by 5px, fixed by giving it the datasheet treatment.
+ *
+ * Usage: yarn lint:overflow  (expects a server on PORT serving build/)
+ * Skips with exit 0, loudly, when Chrome is not installed: this is a local
+ * quality gate, not something that should fail a machine that lacks a browser.
+ */
+import { existsSync } from 'fs';
+import { spawn } from 'child_process';
+import { createServer } from 'http';
+import { readFile } from 'fs/promises';
+import { extname, join, normalize } from 'path';
+
+// Node's built-in WebSocket, unflagged from Node 22. Deliberately not the `ws`
+// package: that is only present here as a transitive dependency of
+// eleventy-dev-server, so importing it would work today and break silently the
+// day Eleventy changes its dependency tree. package.json still declares
+// `node >= 18`, which has no WebSocket, so this degrades rather than throws.
+const WebSocket = globalThis.WebSocket;
+if (!WebSocket) {
+  console.log('⏭  check-overflow skipped: needs Node 22+ for the built-in WebSocket.');
+  process.exit(0);
+}
+
+const WIDTHS = [320, 360, 390, 414];
+const PAGES = [
+  '/', '/all/', '/blog/', '/digesting/', '/archive/', '/directory/',
+  '/cv/', '/stats/', '/search/', '/work/', '/garage/', '/colophon/',
+];
+const TOLERANCE = 1; // sub-pixel rounding, not a layout fault
+const PORT = 8123;
+const CDP_PORT = 9444;
+
+const CHROME_PATHS = [
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/usr/bin/google-chrome-stable',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium-browser',
+  '/usr/bin/chromium',
+];
+const chrome = CHROME_PATHS.find((p) => existsSync(p));
+if (!chrome) {
+  console.log('⏭  check-overflow skipped: no Chrome/Chromium found.');
+  process.exit(0);
+}
+
+const MIME = { '.html': 'text/html', '.css': 'text/css', '.js': 'text/javascript', '.svg': 'image/svg+xml', '.json': 'application/json' };
+const server = createServer(async (req, res) => {
+  try {
+    let p = normalize(decodeURIComponent(req.url.split('?')[0]));
+    if (p.endsWith('/')) p += 'index.html';
+    const body = await readFile(join('build', p));
+    res.writeHead(200, { 'Content-Type': MIME[extname(p)] || 'application/octet-stream' });
+    res.end(body);
+  } catch { res.writeHead(404); res.end('nope'); }
+});
+await new Promise((r) => server.listen(PORT, r));
+
+const proc = spawn(chrome, [
+  '--headless=new', '--disable-gpu', '--no-sandbox',
+  `--remote-debugging-port=${CDP_PORT}`, '--user-data-dir=/tmp/kh-overflow-profile', 'about:blank',
+], { stdio: 'ignore' });
+
+let id = 0;
+const send = (ws, method, params = {}) => new Promise((resolve) => {
+  const i = ++id;
+  const on = (ev) => {
+    const m = JSON.parse(ev.data);
+    if (m.id === i) { ws.removeEventListener('message', on); resolve(m.result); }
+  };
+  ws.addEventListener('message', on);
+  ws.send(JSON.stringify({ id: i, method, params }));
+});
+const waitFor = (ws, method) => new Promise((resolve) => {
+  const t = setTimeout(() => { ws.removeEventListener('message', on); resolve(null); }, 10000);
+  const on = (ev) => {
+    const m = JSON.parse(ev.data);
+    if (m.method === method) { clearTimeout(t); ws.removeEventListener('message', on); resolve(m.params); }
+  };
+  ws.addEventListener('message', on);
+});
+
+// Names the offenders, skipping anything inside a scroll/clip container, whose
+// overflow is contained on purpose (the timeline strip, table scrollers).
+const PROBE = `(() => {
+  const de = document.documentElement;
+  const over = de.scrollWidth - de.clientWidth;
+  if (over <= ${TOLERANCE}) return JSON.stringify({ over: 0, items: [] });
+  const items = [];
+  for (const el of document.querySelectorAll('body *')) {
+    const r = el.getBoundingClientRect();
+    if (!(r.width || r.height)) continue;
+    if (getComputedStyle(el).position === 'fixed') continue;
+    if (r.right <= de.clientWidth + ${TOLERANCE}) continue;
+    let p = el.parentElement, clipped = false;
+    while (p && p !== document.body) {
+      const ox = getComputedStyle(p).overflowX;
+      if (ox === 'auto' || ox === 'scroll' || ox === 'hidden' || ox === 'clip') { clipped = true; break; }
+      p = p.parentElement;
+    }
+    if (clipped) continue;
+    items.push((el.tagName.toLowerCase()
+      + (el.id ? '#' + el.id : '')
+      + (typeof el.className === 'string' && el.className.trim()
+          ? '.' + el.className.trim().split(/\\s+/).slice(0, 3).join('.') : ''))
+      + '  (+' + Math.round(r.right - de.clientWidth) + 'px)');
+  }
+  return JSON.stringify({ over, items: [...new Set(items)].slice(0, 5) });
+})()`;
+
+let ws, failures = 0, checked = 0;
+try {
+  for (let i = 0; i < 40 && !ws; i++) {
+    try {
+      const tab = await (await fetch(`http://127.0.0.1:${CDP_PORT}/json/new?about:blank`, { method: 'PUT' })).json();
+      ws = new WebSocket(tab.webSocketDebuggerUrl);
+      await new Promise((res, rej) => {
+        ws.addEventListener('open', res, { once: true });
+        ws.addEventListener('error', rej, { once: true });
+      });
+    } catch { ws = null; await new Promise((r) => setTimeout(r, 250)); }
+  }
+  if (!ws) throw new Error('could not reach Chrome over CDP');
+  await send(ws, 'Page.enable');
+
+  for (const width of WIDTHS) {
+    await send(ws, 'Emulation.setDeviceMetricsOverride', { width, height: 900, deviceScaleFactor: 1, mobile: true });
+    for (const page of PAGES) {
+      await send(ws, 'Page.navigate', { url: `http://127.0.0.1:${PORT}${page}` });
+      await waitFor(ws, 'Page.loadEventFired');
+      await new Promise((r) => setTimeout(r, 120));
+      const { result } = await send(ws, 'Runtime.evaluate', { expression: PROBE, returnByValue: true });
+      const data = JSON.parse(result.value);
+      checked++;
+      if (data.over > TOLERANCE) {
+        failures++;
+        console.error(`\n❌ ${page} at ${width}px overflows by ${data.over}px`);
+        for (const it of data.items) console.error(`     ${it}`);
+      }
+    }
+  }
+} finally {
+  if (ws) ws.close();
+  proc.kill();
+  server.close();
+}
+
+if (failures) {
+  console.error(`\n${failures} of ${checked} page/width combinations scroll sideways.`);
+  console.error('A page that scrolls horizontally on a phone is the most-felt layout bug there is.\n');
+  process.exit(1);
+}
+console.log(`✅ No horizontal overflow. ${checked} page/width combinations checked (${WIDTHS.join(', ')}px).`);

--- a/src/components/vf-componenet-rollup/_semantic-search.scss
+++ b/src/components/vf-componenet-rollup/_semantic-search.scss
@@ -271,14 +271,38 @@
 
   // Shared search form layout (keyword + semantic). Field and button share a
   // single hairline row rather than floating apart.
-  .kh-search-widget__form {
+  // Two search controls share one treatment: the semantic widget on /search/,
+  // and the inline box `partials/search-box.njk` puts on /all/, /blog/,
+  // /digesting/ and the topic pages. They were diverging -- the inline one fell
+  // through to the generic `.kh-form__input` padding and `.kh-button`'s
+  // `align-self: center`, so it rendered as an oversized rounded field with a
+  // small button floating beside it, next to a datasheet-register listing.
+  // The declarations are grouped rather than duplicated. The flex container is
+  // a different element in each (the form itself for the widget, `__item` for
+  // the inline box, since that is what wraps the input and button), which is
+  // why the selectors are not simply one class.
+  .kh-search-widget__form,
+  .kh-form--search .kh-form__item {
     align-items: stretch;
     display: flex;
     gap: 0;
+  }
+
+  // Widget only: the inline form carries its own bottom margin in the markup.
+  .kh-search-widget__form {
     margin: 0.5rem 0 1rem;
   }
 
-  .kh-search-widget__form .kh-form__input {
+  // Inline form only. The widget is bounded by its panel's 48rem measure; this
+  // one sits on a full-width listing, and without a cap the `flex: 1` field
+  // spans the entire content width and strands the button at the far edge.
+  // It is a control, not a banner.
+  .kh-form--search {
+    max-width: 26rem;
+  }
+
+  .kh-search-widget__form .kh-form__input,
+  .kh-form--search .kh-form__input {
     background: #fff;
     border: 1px solid var(--kh-rule--strong);
     flex: 1;
@@ -287,7 +311,11 @@
     padding: 0.7rem 0.9rem;
   }
 
-  .kh-search-widget__form .kh-button {
+  // `align-self: stretch` overrides the `center` on `.kh-button`, which is what
+  // left the button short of the input's height.
+  .kh-search-widget__form .kh-button,
+  .kh-form--search .kh-button {
+    align-self: stretch;
     border-left: 0;
     flex-shrink: 0;
     margin: 0;


### PR DESCRIPTION
## The headline: there was almost no overflow to fix

I reported earlier that the site "has real horizontal overflow below about 640px, with nav, body text and post titles all clipping at 420px". **That was wrong, and this PR is partly the correction.**

The measurement was taken by screenshotting headless Chrome at a narrow window size. Without mobile emulation, headless Chrome ignores the `width=device-width` viewport meta and lays a 420px window out as a desktop page. Everything clips, and none of it means anything about the real site.

Measured properly, with `Emulation.setDeviceMetricsOverride` and `mobile: true`, the site is clean at 320, 360, 375, 390, 414 and 600px, and clean on desktop at 800, 1024 and 1440px.

## What was actually wrong: one element

The inline search box overflowed **320px by 5px**. That is a real device width, so it was a real bug, and it is the only one across 48 page/width combinations.

The cause: `partials/search-box.njk` had no styling of its own and fell through to the generic `.kh-form__input { padding: 1rem; margin-right: 0.5rem }` plus `.kh-button`'s `align-self: center`. Fixed by giving it the same treatment `/search/`'s widget already had — field and button in one hairline row, `min-width: 0` so the field can actually shrink.

That commit is cherry-picked from #129, where it was made for a separate reason (it looked out of place next to the datasheet listings). Identical content in both branches, so whichever merges second should be clean.

## Things checked and found innocent

- **`width: 100vw` in the ambience layer** (`_kh-ambience.scss:79`, `:110`). `100vw` includes the scrollbar, which is the classic cause of a few pixels of desktop overflow. Here it is contained by `#kh-dappled-light`'s `overflow: hidden`, and desktop widths measured clean.
- **The full-bleed utility** (`index.scss`, `margin-left: -50vw; width: 100vw`). Also clean.
- **A 2px overflow at 280px**, on some pages. Chased it properly: hiding *every* candidate element one at a time, no single element reduced `scrollWidth`. It is sub-pixel rounding with no responsible element, and 280px is below any mainstream phone. Not fixed, deliberately.

## The durable part: `yarn lint:overflow`

Horizontal overflow is a layout outcome, not a property of the stylesheet. A long unbreakable URL, a wide table, a new full-bleed element or a `100vw` beside a scrollbar all cause it, and none is visible by reading CSS. So the check drives a real browser: 12 pages × 4 device widths, failing with the offending selector and the overflow in pixels.

Two design notes:

- **It uses mobile emulation**, precisely so nobody repeats the false alarm above. That reasoning is in the file's header comment.
- **Zero new dependencies.** It uses Node's built-in `WebSocket` (unflagged from Node 22; CI runs 22) rather than the `ws` package, which is only present as a transitive dependency of eleventy-dev-server and would break silently if Eleventy changed its tree. It serves `build/` itself, so it needs no dev server running.

It skips with exit 0, loudly, when Chrome or a modern-enough Node is missing, so it can never become a mysterious failure on a machine without a browser.

Verified both ways: green on this branch, and correctly red when fed a deliberate regression (a `min-width: 700px` injected into the listing), which it reported as `div.kh-datasheet-list (+398px)` with the affected descendants beneath it.

**Not wired into `yarn build` or CI.** It needs a browser and takes about a minute, and that is your call rather than mine. If you want it in CI, the runners already have Chrome and it is one step after the build:

```yaml
      - name: Check for horizontal overflow 📱
        run: yarn lint:overflow
```

## Verification

`yarn lint:css` clean; full `yarn build` green; `yarn lint:links` reports no broken links; `yarn test` passes; `yarn lint:overflow` green across 48 combinations.
